### PR TITLE
feat!: add basic support for aqua precise data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__
 .vscode
 *.egg-info
 dist
+build

--- a/gardena_bluetooth/__init__.py
+++ b/gardena_bluetooth/__init__.py
@@ -3,20 +3,24 @@ from __future__ import annotations
 from bleak.uuids import register_uuids
 
 from .const import ScanService
-from .parse import Service
+from .parse import Service, Characteristic
+
+
+def prefix(name: str) -> str:
+    return f"Gardena {name}"
+
 
 register_uuids(
     {
-        service.uuid: f"Gardena {service.__name__}"
-        for service in Service.registry.values()
+        uuid: prefix(", ".join(service.__name__ for service in services))
+        for uuid, services in Service.registry.items()
     }
 )
 
 register_uuids(
     {
-        char.uuid: f"Gardena {service.__name__} {char.name}"
-        for service in Service.registry.values()
-        for char in service.characteristics()
+        uuid: prefix(", ".join(char.name for char in chars))
+        for uuid, chars in Characteristic.registry.items()
     }
 )
 

--- a/gardena_bluetooth/__main__.py
+++ b/gardena_bluetooth/__main__.py
@@ -1,4 +1,4 @@
-import anyio
+import asyncio
 import asyncclick as click
 from bleak import (
     AdvertisementData,
@@ -44,7 +44,8 @@ async def scan():
         click.echo()
 
     async with BleakScanner(detected, service_uuids=[ScanService, FotaService]):
-        await anyio.sleep_forever()
+        while True:
+            await asyncio.sleep(1)
 
 
 @main.command()
@@ -66,9 +67,9 @@ async def connect(address: str):
                 if data is not None and parser:
                     click.echo(f" -  Data: {parser.decode(data)}")
 
-            async with anyio.create_task_group() as tg:
+            async with asyncio.TaskGroup() as tg:
                 for char in service.characteristics:
-                    tg.start_soon(read_print, char)
+                    tg.create_task(read_print(char))
 
 
 @main.command()

--- a/gardena_bluetooth/__main__.py
+++ b/gardena_bluetooth/__main__.py
@@ -10,7 +10,7 @@ from bleak import (
 from bleak.uuids import uuidstr_to_str
 
 from .const import FotaService, ScanService
-from .parse import Characteristic, ManufacturerData
+from .parse import Characteristic, ManufacturerData, Service
 
 
 @click.group()
@@ -56,16 +56,23 @@ async def connect(address: str):
         for service in client.services:
             click.echo(f"Service: {service}")
 
+            service_parser = Service.registry.get(service.uuid)
+
             async def read_print(char: BleakGATTCharacteristic):
-                parser = Characteristic.registry.get(char.uuid)
                 if "read" in char.properties:
                     data = await client.read_gatt_char(char.uuid)
                 else:
                     data = None
                 click.echo(f" -  {char}")
-                click.echo(f" -  {char.properties}")
-                if data is not None and parser:
-                    click.echo(f" -  Data: {parser.decode(data)}")
+                click.echo(f"    Prop: {char.properties}")
+
+                if data is not None:
+                    if service_parser and (
+                        parser := service_parser[0].characteristics.get(char.uuid)
+                    ):
+                        click.echo(f"    Data: {parser.decode(data)}")
+                    else:
+                        click.echo(f"    Data: {data}")
 
             async with asyncio.TaskGroup() as tg:
                 for char in service.characteristics:

--- a/gardena_bluetooth/__main__.py
+++ b/gardena_bluetooth/__main__.py
@@ -3,7 +3,7 @@ import asyncclick as click
 from bleak import (
     AdvertisementData,
     BleakClient,
-    BleakGATTCharacteristic,
+    BleakError,
     BleakScanner,
     BLEDevice,
 )
@@ -76,13 +76,16 @@ async def connect(address: str):
 
             service_parser = Service.find_service(service.uuid, product_type)
 
-            async def read_print(char: BleakGATTCharacteristic):
-                if "read" in char.properties:
-                    data = await client.read_gatt_char(char.uuid)
-                else:
-                    data = None
+            for char in service.characteristics:
                 click.echo(f" -  {char}")
                 click.echo(f"    Prop: {char.properties}")
+
+                data = None
+                if "read" in char.properties:
+                    try:
+                        data = await client.read_gatt_char(char.uuid)
+                    except BleakError as exc:
+                        click.echo(f"    Failed: {repr(exc)}")
 
                 if data is not None:
                     if service_parser and (
@@ -91,10 +94,6 @@ async def connect(address: str):
                         click.echo(f"    Data: {parser.decode(data)}")
                     else:
                         click.echo(f"    Data: {data}")
-
-            async with asyncio.TaskGroup() as tg:
-                for char in service.characteristics:
-                    tg.create_task(read_print(char))
 
 
 @main.command()

--- a/gardena_bluetooth/__main__.py
+++ b/gardena_bluetooth/__main__.py
@@ -58,13 +58,17 @@ async def connect(address: str):
                 if device.address != address:
                     continue
                 if ManufacturerData.company not in data.manufacturer_data:
-                    click.echo("No manufacturer data found in advertisement")
+                    click.echo("No manufacturer data found in advertisement skipping")
                     continue
+                manufacturer_data = ManufacturerData.decode(
+                    data.manufacturer_data[ManufacturerData.company]
+                )
+                if manufacturer_data.model is None:
+                    click.echo("No model found in manufacturer data skipping")
+                    continue
+
                 break
 
-    manufacturer_data = ManufacturerData.decode(
-        data.manufacturer_data[ManufacturerData.company]
-    )
     product_type = ProductType.from_manufacturer_data(manufacturer_data)
 
     click.echo(f"Advertised data: {manufacturer_data}")

--- a/gardena_bluetooth/__main__.py
+++ b/gardena_bluetooth/__main__.py
@@ -77,12 +77,20 @@ async def connect(address: str):
 
     async with BleakClient(device, timeout=20) as client:
         for service in client.services:
-            click.echo(f"Service: {service}")
-
             service_parser = Service.find_service(service.uuid, product_type)
 
+            click.echo(
+                f"Service: {service.uuid}: {service_parser.__name__ if service_parser else service.description}"
+            )
+
             for char in service.characteristics:
-                click.echo(f" -  {char}")
+                char_parser = None
+                if service_parser:
+                    char_parser = service_parser.characteristics.get(char.uuid)
+
+                click.echo(
+                    f" -  {char.uuid}: {char_parser.name if char_parser else char.description}"
+                )
                 click.echo(f"    Prop: {char.properties}")
 
                 data = None
@@ -93,10 +101,8 @@ async def connect(address: str):
                         click.echo(f"    Failed: {repr(exc)}")
 
                 if data is not None:
-                    if service_parser and (
-                        parser := service_parser.characteristics.get(char.uuid)
-                    ):
-                        click.echo(f"    Data: {parser.decode(data)}")
+                    if char_parser:
+                        click.echo(f"    Data: {char_parser.decode(data)}")
                     else:
                         click.echo(f"    Data: {data}")
 

--- a/gardena_bluetooth/__main__.py
+++ b/gardena_bluetooth/__main__.py
@@ -10,7 +10,7 @@ from bleak import (
 from bleak.uuids import uuidstr_to_str
 
 from .const import FotaService, ScanService
-from .parse import Characteristic, ManufacturerData, Service
+from .parse import Characteristic, ManufacturerData, ProductType, Service
 
 
 @click.group()
@@ -52,11 +52,29 @@ async def scan():
 @click.argument("address")
 async def connect(address: str):
     click.echo(f"Connecting to: {address}")
-    async with BleakClient(address, timeout=20) as client:
+    async with BleakScanner(service_uuids=[ScanService, FotaService]) as scanner:
+        async with asyncio.timeout(10):
+            async for device, data in scanner.advertisement_data():
+                if device.address != address:
+                    continue
+                if ManufacturerData.company not in data.manufacturer_data:
+                    click.echo("No manufacturer data found in advertisement")
+                    continue
+                break
+
+    manufacturer_data = ManufacturerData.decode(
+        data.manufacturer_data[ManufacturerData.company]
+    )
+    product_type = ProductType.from_manufacturer_data(manufacturer_data)
+
+    click.echo(f"Advertised data: {manufacturer_data}")
+    click.echo(f"Product type: {ProductType.from_manufacturer_data(manufacturer_data)}")
+
+    async with BleakClient(device, timeout=20) as client:
         for service in client.services:
             click.echo(f"Service: {service}")
 
-            service_parser = Service.registry.get(service.uuid)
+            service_parser = Service.find_service(service.uuid, product_type)
 
             async def read_print(char: BleakGATTCharacteristic):
                 if "read" in char.properties:
@@ -68,7 +86,7 @@ async def connect(address: str):
 
                 if data is not None:
                     if service_parser and (
-                        parser := service_parser[0].characteristics.get(char.uuid)
+                        parser := service_parser.characteristics.get(char.uuid)
                     ):
                         click.echo(f"    Data: {parser.decode(data)}")
                     else:

--- a/gardena_bluetooth/__main__.py
+++ b/gardena_bluetooth/__main__.py
@@ -52,27 +52,28 @@ async def scan():
 @click.argument("address")
 async def connect(address: str):
     click.echo(f"Connecting to: {address}")
+
+    manufacturer_data = ManufacturerData()
     async with BleakScanner(service_uuids=[ScanService, FotaService]) as scanner:
         async with asyncio.timeout(10):
             async for device, data in scanner.advertisement_data():
                 if device.address != address:
                     continue
-                if ManufacturerData.company not in data.manufacturer_data:
-                    click.echo("No manufacturer data found in advertisement skipping")
+
+                raw = data.manufacturer_data.get(ManufacturerData.company)
+                if raw is None:
                     continue
-                manufacturer_data = ManufacturerData.decode(
-                    data.manufacturer_data[ManufacturerData.company]
-                )
-                if manufacturer_data.model is None:
-                    click.echo("No model found in manufacturer data skipping")
+
+                manufacturer_data.update(raw)
+
+                product_type = ProductType.from_manufacturer_data(manufacturer_data)
+                if product_type is ProductType.UNKNOWN:
                     continue
 
                 break
 
-    product_type = ProductType.from_manufacturer_data(manufacturer_data)
-
     click.echo(f"Advertised data: {manufacturer_data}")
-    click.echo(f"Product type: {ProductType.from_manufacturer_data(manufacturer_data)}")
+    click.echo(f"Product type: {product_type}")
 
     async with BleakClient(device, timeout=20) as client:
         for service in client.services:

--- a/gardena_bluetooth/client.py
+++ b/gardena_bluetooth/client.py
@@ -10,13 +10,12 @@ from bleak.exc import BleakError
 from bleak.backends.device import BLEDevice
 from bleak_retry_connector import establish_connection
 
-from .const import DeviceConfiguration
 from .exceptions import (
     CharacteristicNoAccess,
     CharacteristicNotFound,
     CommunicationFailure,
 )
-from .parse import Characteristic, CharacteristicType
+from .parse import Characteristic, CharacteristicTime, CharacteristicType
 
 LOGGER = logging.getLogger(__name__)
 DEFAULT_MISSING = object()
@@ -199,9 +198,9 @@ class Client:
         data = char.encode(value)
         await self.write_char_raw(char.uuid, data, response)
 
-    async def update_timestamp(self, now: datetime):
+    async def update_timestamp(self, char: CharacteristicTime, now: datetime):
         try:
-            timestamp = await self.read_char(DeviceConfiguration.unix_timestamp)
+            timestamp = await self.read_char(char)
         except CharacteristicNoAccess:
             LOGGER.debug("No timestamp defined for device")
             return
@@ -212,7 +211,7 @@ class Client:
                 "Updating time on device to match local time delta was %s", delta
             )
             await self.write_char(
-                DeviceConfiguration.unix_timestamp,
+                char,
                 now.replace(tzinfo=None),
                 True,
             )

--- a/gardena_bluetooth/const.py
+++ b/gardena_bluetooth/const.py
@@ -47,6 +47,7 @@ class Valve(Service):
 
 class DeviceConfiguration(Service):
     uuid = "98bd0b10-0b0e-421a-84e5-ddbf75dc6de4"
+    products = set(ProductType) - {ProductType.AQUA_CONTOURS}
 
     rain_pause = CharacteristicLong("98bd0b11-0b0e-421a-84e5-ddbf75dc6de4")
     seasonal_adjust = CharacteristicInt("98bd0b12-0b0e-421a-84e5-ddbf75dc6de4")
@@ -58,6 +59,41 @@ class DeviceConfiguration(Service):
     custom_device_name = CharacteristicNullStringUf8(
         "98bd0b18-0b0e-421a-84e5-ddbf75dc6de4"
     )
+
+
+class AquaContourContours(Service):
+    uuid = "98bd0b10-0b0e-421a-84e5-ddbf75dc6de4"
+    products = {ProductType.AQUA_CONTOURS}
+
+    contour_receive = CharacteristicBytes("98bd0b11-0b0e-421a-84e5-ddbf75dc6de4")
+    contour_transmit = CharacteristicBytes("98bd0b12-0b0e-421a-84e5-ddbf75dc6de4")
+    contour_info = CharacteristicBytes("98bd0b13-0b0e-421a-84e5-ddbf75dc6de4")
+    contour_name_1 = CharacteristicNullStringUf8("98bd0b1a-0b0e-421a-84e5-ddbf75dc6de4")
+    contour_name_2 = CharacteristicNullStringUf8("98bd0b1b-0b0e-421a-84e5-ddbf75dc6de4")
+    contour_name_3 = CharacteristicNullStringUf8("98bd0b1c-0b0e-421a-84e5-ddbf75dc6de4")
+    contour_name_4 = CharacteristicNullStringUf8("98bd0b1d-0b0e-421a-84e5-ddbf75dc6de4")
+    contour_name_5 = CharacteristicNullStringUf8("98bd0b1e-0b0e-421a-84e5-ddbf75dc6de4")
+
+
+class AquaContourSchedule(Service):
+    uuid = "98bd0c10-0b0e-421a-84e5-ddbf75dc6de4"
+    products = {ProductType.AQUA_CONTOURS}
+
+    schedule_1 = CharacteristicBytes("98bd0c11-0b0e-421a-84e5-ddbf75dc6de4")
+    schedule_2 = CharacteristicBytes("98bd0c12-0b0e-421a-84e5-ddbf75dc6de4")
+    schedule_3 = CharacteristicBytes("98bd0c13-0b0e-421a-84e5-ddbf75dc6de4")
+    schedule_4 = CharacteristicBytes("98bd0c14-0b0e-421a-84e5-ddbf75dc6de4")
+    schedule_5 = CharacteristicBytes("98bd0c15-0b0e-421a-84e5-ddbf75dc6de4")
+    schedule_6 = CharacteristicBytes("98bd0c16-0b0e-421a-84e5-ddbf75dc6de4")
+    schedule_7 = CharacteristicBytes("98bd0c17-0b0e-421a-84e5-ddbf75dc6de4")
+    schedule_8 = CharacteristicBytes("98bd0c18-0b0e-421a-84e5-ddbf75dc6de4")
+    schedule_9 = CharacteristicBytes("98bd0c19-0b0e-421a-84e5-ddbf75dc6de4")
+    schedule_10 = CharacteristicBytes("98bd0c1a-0b0e-421a-84e5-ddbf75dc6de4")
+    schedule_11 = CharacteristicBytes("98bd0c1b-0b0e-421a-84e5-ddbf75dc6de4")
+    schedule_12 = CharacteristicBytes("98bd0c1c-0b0e-421a-84e5-ddbf75dc6de4")
+    schedule_13 = CharacteristicBytes("98bd0c1d-0b0e-421a-84e5-ddbf75dc6de4")
+    schedule_14 = CharacteristicBytes("98bd0c1e-0b0e-421a-84e5-ddbf75dc6de4")
+    schedule_15 = CharacteristicBytes("98bd0c1f-0b0e-421a-84e5-ddbf75dc6de4")
 
 
 class DeviceInformation(Service):
@@ -92,6 +128,12 @@ class WateringHistory(Service):
     timestamp_count = CharacteristicInt("98bd0d12-0b0e-421a-84e5-ddbf75dc6de4")
     skip_reason = CharacteristicBytes("98bd0d13-0b0e-421a-84e5-ddbf75dc6de4")
     watering_duration = CharacteristicLongArray("98bd0d14-0b0e-421a-84e5-ddbf75dc6de4")
+    watering_skipped = CharacteristicBool("98bd0d15-0b0e-421a-84e5-ddbf75dc6de4")
+    skipped_schedule_number = CharacteristicInt("98bd0d16-0b0e-421a-84e5-ddbf75dc6de4")
+    water_control_error = CharacteristicInt("98bd0d17-0b0e-421a-84e5-ddbf75dc6de4")
+    watering_pause = CharacteristicLong("98bd0d18-0b0e-421a-84e5-ddbf75dc6de4")
+    seasonal_adjust = CharacteristicInt("98bd0d19-0b0e-421a-84e5-ddbf75dc6de4")
+    rain_sensitivity = CharacteristicInt("98bd0d1a-0b0e-421a-84e5-ddbf75dc6de4")
 
 
 class ErrorHistory(Service):
@@ -121,6 +163,66 @@ class Pump(Service):
     error_code = CharacteristicBytes("98bd010f-0b0e-421a-84e5-ddbf75dc6de4")
     user_motor_runtime = CharacteristicLong("98bd0110-0b0e-421a-84e5-ddbf75dc6de4")
     total_motor_runtime = CharacteristicLong("98bd0111-0b0e-421a-84e5-ddbf75dc6de4")
+
+
+class Spray(Service):
+    uuid = "98bd0110-0b0e-421a-84e5-ddbf75dc6de4"
+    distance = CharacteristicInt("98bd0111-0b0e-421a-84e5-ddbf75dc6de4")
+    sector = CharacteristicInt("98bd0112-0b0e-421a-84e5-ddbf75dc6de4")
+    current_distance = CharacteristicInt("98bd0113-0b0e-421a-84e5-ddbf75dc6de4")
+    current_sector = CharacteristicInt("98bd0114-0b0e-421a-84e5-ddbf75dc6de4")
+    watering_mode_error = CharacteristicInt("98bd0115-0b0e-421a-84e5-ddbf75dc6de4")
+
+
+class EventHistory(Service):
+    uuid = "98bd0120-0b0e-421a-84e5-ddbf75dc6de4"
+    history = CharacteristicBytes("98bd0121-0b0e-421a-84e5-ddbf75dc6de4")
+    error = CharacteristicBytes("98bd0122-0b0e-421a-84e5-ddbf75dc6de4")
+
+
+class AquaContour(Service):
+    uuid = "98bd0a10-0b0e-421a-84e5-ddbf75dc6de4"
+    unix_timestamp = CharacteristicTime("98bd0a11-0b0e-421a-84e5-ddbf75dc6de4")
+    custom_device_name = CharacteristicNullStringUf8(
+        "98bd0a12-0b0e-421a-84e5-ddbf75dc6de4"
+    )
+    frost_warning = CharacteristicBool("98bd0a15-0b0e-421a-84e5-ddbf75dc6de4")
+    active_contour = CharacteristicBytes("98bd0a16-0b0e-421a-84e5-ddbf75dc6de4")
+
+
+class FlowStatistics(Service):
+    uuid = "98bd0e10-0b0e-421a-84e5-ddbf75dc6de4"
+    overall = CharacteristicLong("98bd0e16-0b0e-421a-84e5-ddbf75dc6de4")
+    resettable = CharacteristicLong("98bd0e17-0b0e-421a-84e5-ddbf75dc6de4")
+    last_reset = CharacteristicTime("98bd0e18-0b0e-421a-84e5-ddbf75dc6de4")
+    current = CharacteristicInt("98bd0e19-0b0e-421a-84e5-ddbf75dc6de4")
+
+
+class AquaContourPosition(Service):
+    uuid = "98bd0130-0b0e-421a-84e5-ddbf75dc6de4"
+    active_position = CharacteristicInt("98bd0132-0b0e-421a-84e5-ddbf75dc6de4")
+    position_mask = CharacteristicBytes("98bd0135-0b0e-421a-84e5-ddbf75dc6de4")
+    position_name_1 = CharacteristicNullStringUf8(
+        "98bd013a-0b0e-421a-84e5-ddbf75dc6de4"
+    )
+    position_name_2 = CharacteristicNullStringUf8(
+        "98bd013b-0b0e-421a-84e5-ddbf75dc6de4"
+    )
+    position_name_3 = CharacteristicNullStringUf8(
+        "98bd013c-0b0e-421a-84e5-ddbf75dc6de4"
+    )
+    position_name_4 = CharacteristicNullStringUf8(
+        "98bd013d-0b0e-421a-84e5-ddbf75dc6de4"
+    )
+    position_name_5 = CharacteristicNullStringUf8(
+        "98bd013e-0b0e-421a-84e5-ddbf75dc6de4"
+    )
+
+
+class AquaContourBattery(Service):
+    uuid = "0000180f-0000-1000-8000-00805f9b34fb"
+    battery_level = CharacteristicInt("00002a19-0000-1000-8000-00805f9b34fb")
+    battery_level_status = CharacteristicInt("00002bed-0000-1000-8000-00805f9b34fb")
 
 
 class Reset(Service):

--- a/gardena_bluetooth/const.py
+++ b/gardena_bluetooth/const.py
@@ -1,5 +1,7 @@
+from abc import ABC
 from .parse import (
     CharacteristicBool,
+    CharacteristicWeekday,
     CharacteristicBytes,
     CharacteristicInt,
     CharacteristicLong,
@@ -98,6 +100,43 @@ class AquaContourSchedule(Service):
     schedule_13 = CharacteristicBytes("98bd0c1d-0b0e-421a-84e5-ddbf75dc6de4")
     schedule_14 = CharacteristicBytes("98bd0c1e-0b0e-421a-84e5-ddbf75dc6de4")
     schedule_15 = CharacteristicBytes("98bd0c1f-0b0e-421a-84e5-ddbf75dc6de4")
+
+
+class Schedule(Service, ABC):
+    products = set(ProductType) - {ProductType.AQUA_CONTOURS}
+
+    def __init_subclass__(cls, *, instance: int, **kwargs):
+        def _uuid(offset: int) -> str:
+            return f"98bd0c{0x10 * instance + offset:02x}-0b0e-421a-84e5-ddbf75dc6de4"
+
+        cls.uuid = _uuid(0)
+        cls.start_time = CharacteristicLong(_uuid(1), "Start Time")
+        cls.duration = CharacteristicLong(_uuid(2), "Duration")
+        cls.weekdays = CharacteristicWeekday(_uuid(3), "Weekdays")
+        cls.valve_link = CharacteristicBytes(_uuid(4), "Valve Link")
+        cls.active = CharacteristicBool(_uuid(5), "Active")
+        cls.sensor_link = CharacteristicBool(_uuid(6), "Sensor Link")
+        super().__init_subclass__(**kwargs)
+
+
+class Schedule_1(Schedule, instance=1):
+    pass
+
+
+class Schedule_2(Schedule, instance=2):
+    pass
+
+
+class Schedule_3(Schedule, instance=3):
+    pass
+
+
+class Schedule_4(Schedule, instance=4):
+    pass
+
+
+class Schedule_5(Schedule, instance=5):
+    pass
 
 
 class DeviceInformation(Service):

--- a/gardena_bluetooth/const.py
+++ b/gardena_bluetooth/const.py
@@ -128,12 +128,12 @@ class Schedule(Service, ABC):
             return f"98bd0c{0x10 * instance + offset:02x}-0b0e-421a-84e5-ddbf75dc6de4"
 
         cls.uuid = _uuid(0)
-        cls.start_time = CharacteristicLong(_uuid(1), "Start Time")
-        cls.duration = CharacteristicLong(_uuid(2), "Duration")
-        cls.weekdays = CharacteristicWeekday(_uuid(3), "Weekdays")
-        cls.valve_link = CharacteristicBytes(_uuid(4), "Valve Link")
-        cls.active = CharacteristicBool(_uuid(5), "Active")
-        cls.sensor_link = CharacteristicBool(_uuid(6), "Sensor Link")
+        cls.start_time = CharacteristicLong(_uuid(1), name="Start Time")
+        cls.duration = CharacteristicLong(_uuid(2), name="Duration")
+        cls.weekdays = CharacteristicWeekday(_uuid(3), name="Weekdays")
+        cls.valve_link = CharacteristicBytes(_uuid(4), name="Valve Link")
+        cls.active = CharacteristicBool(_uuid(5), name="Active")
+        cls.sensor_link = CharacteristicBool(_uuid(6), name="Sensor Link")
         super().__init_subclass__(**kwargs)
 
 

--- a/gardena_bluetooth/const.py
+++ b/gardena_bluetooth/const.py
@@ -32,10 +32,10 @@ FotaService = "0000ffc0-0000-1000-8000-00805f9b34fb"
 class Scan(Service):
     uuid = "98bd0001-0b0e-421a-84e5-ddbf75dc6de4"
 
-    write_characteristic = CharacteristicBytes("98BD0002-0B0E-421A-84E5-DDBF75DC6DE4")
-    read_characteristic = CharacteristicBytes("98BD0003-0B0E-421A-84E5-DDBF75DC6DE4")
+    write_characteristic = CharacteristicBytes("98bd0002-0b0e-421a-84e5-ddbf75dc6de4")
+    read_characteristic = CharacteristicBytes("98bd0003-0b0e-421a-84e5-ddbf75dc6de4")
     read_protocol_descriptor = CharacteristicNullString(
-        "98BD0004-0B0E-421A-84E5-DDBF75DC6DE4"
+        "98bd0004-0b0e-421a-84e5-ddbf75dc6de4"
     )
 
 

--- a/gardena_bluetooth/const.py
+++ b/gardena_bluetooth/const.py
@@ -19,6 +19,10 @@ PRODUCT_NAMES = {
     ProductType.WATER_COMPUTER: "Gardena Water Computer",
     ProductType.VALVE: "Gardena Irrigation Valve",
     ProductType.MOWER: "Gardena Mower",
+    ProductType.AQUA_CONTOURS: "Gardena Aqua Precise",
+    ProductType.AUTOMATS: "Gardena Automats",
+    ProductType.PRESSURE_TANKS: "Gardena Pressure Tanks",
+    ProductType.UNKNOWN: "Gardena Unknown Product",
 }
 
 ScanService = "98bd0001-0b0e-421a-84e5-ddbf75dc6de4"

--- a/gardena_bluetooth/const.py
+++ b/gardena_bluetooth/const.py
@@ -103,21 +103,51 @@ class AquaContourSchedule(Service):
     products = {ProductType.AQUA_CONTOURS}
     variant = "1"
 
-    schedule_1 = CharacteristicBytes("98bd0c11-0b0e-421a-84e5-ddbf75dc6de4")
-    schedule_2 = CharacteristicBytes("98bd0c12-0b0e-421a-84e5-ddbf75dc6de4")
-    schedule_3 = CharacteristicBytes("98bd0c13-0b0e-421a-84e5-ddbf75dc6de4")
-    schedule_4 = CharacteristicBytes("98bd0c14-0b0e-421a-84e5-ddbf75dc6de4")
-    schedule_5 = CharacteristicBytes("98bd0c15-0b0e-421a-84e5-ddbf75dc6de4")
-    schedule_6 = CharacteristicBytes("98bd0c16-0b0e-421a-84e5-ddbf75dc6de4")
-    schedule_7 = CharacteristicBytes("98bd0c17-0b0e-421a-84e5-ddbf75dc6de4")
-    schedule_8 = CharacteristicBytes("98bd0c18-0b0e-421a-84e5-ddbf75dc6de4")
-    schedule_9 = CharacteristicBytes("98bd0c19-0b0e-421a-84e5-ddbf75dc6de4")
-    schedule_10 = CharacteristicBytes("98bd0c1a-0b0e-421a-84e5-ddbf75dc6de4")
-    schedule_11 = CharacteristicBytes("98bd0c1b-0b0e-421a-84e5-ddbf75dc6de4")
-    schedule_12 = CharacteristicBytes("98bd0c1c-0b0e-421a-84e5-ddbf75dc6de4")
-    schedule_13 = CharacteristicBytes("98bd0c1d-0b0e-421a-84e5-ddbf75dc6de4")
-    schedule_14 = CharacteristicBytes("98bd0c1e-0b0e-421a-84e5-ddbf75dc6de4")
-    schedule_15 = CharacteristicBytes("98bd0c1f-0b0e-421a-84e5-ddbf75dc6de4")
+    schedule_1 = CharacteristicBytes(
+        "98bd0c11-0b0e-421a-84e5-ddbf75dc6de4", variant="1"
+    )
+    schedule_2 = CharacteristicBytes(
+        "98bd0c12-0b0e-421a-84e5-ddbf75dc6de4", variant="1"
+    )
+    schedule_3 = CharacteristicBytes(
+        "98bd0c13-0b0e-421a-84e5-ddbf75dc6de4", variant="1"
+    )
+    schedule_4 = CharacteristicBytes(
+        "98bd0c14-0b0e-421a-84e5-ddbf75dc6de4", variant="1"
+    )
+    schedule_5 = CharacteristicBytes(
+        "98bd0c15-0b0e-421a-84e5-ddbf75dc6de4", variant="1"
+    )
+    schedule_6 = CharacteristicBytes(
+        "98bd0c16-0b0e-421a-84e5-ddbf75dc6de4", variant="1"
+    )
+    schedule_7 = CharacteristicBytes(
+        "98bd0c17-0b0e-421a-84e5-ddbf75dc6de4", variant="1"
+    )
+    schedule_8 = CharacteristicBytes(
+        "98bd0c18-0b0e-421a-84e5-ddbf75dc6de4", variant="1"
+    )
+    schedule_9 = CharacteristicBytes(
+        "98bd0c19-0b0e-421a-84e5-ddbf75dc6de4", variant="1"
+    )
+    schedule_10 = CharacteristicBytes(
+        "98bd0c1a-0b0e-421a-84e5-ddbf75dc6de4", variant="1"
+    )
+    schedule_11 = CharacteristicBytes(
+        "98bd0c1b-0b0e-421a-84e5-ddbf75dc6de4", variant="1"
+    )
+    schedule_12 = CharacteristicBytes(
+        "98bd0c1c-0b0e-421a-84e5-ddbf75dc6de4", variant="1"
+    )
+    schedule_13 = CharacteristicBytes(
+        "98bd0c1d-0b0e-421a-84e5-ddbf75dc6de4", variant="1"
+    )
+    schedule_14 = CharacteristicBytes(
+        "98bd0c1e-0b0e-421a-84e5-ddbf75dc6de4", variant="1"
+    )
+    schedule_15 = CharacteristicBytes(
+        "98bd0c1f-0b0e-421a-84e5-ddbf75dc6de4", variant="1"
+    )
 
 
 class Schedule(Service, ABC):

--- a/gardena_bluetooth/const.py
+++ b/gardena_bluetooth/const.py
@@ -70,20 +70,38 @@ class DeviceConfiguration(Service):
 class AquaContourContours(Service):
     uuid = "98bd0b10-0b0e-421a-84e5-ddbf75dc6de4"
     products = {ProductType.AQUA_CONTOURS}
+    variant = "1"
 
-    contour_receive = CharacteristicBytes("98bd0b11-0b0e-421a-84e5-ddbf75dc6de4")
-    contour_transmit = CharacteristicBytes("98bd0b12-0b0e-421a-84e5-ddbf75dc6de4")
-    contour_info = CharacteristicBytes("98bd0b13-0b0e-421a-84e5-ddbf75dc6de4")
-    contour_name_1 = CharacteristicNullStringUf8("98bd0b1a-0b0e-421a-84e5-ddbf75dc6de4")
-    contour_name_2 = CharacteristicNullStringUf8("98bd0b1b-0b0e-421a-84e5-ddbf75dc6de4")
-    contour_name_3 = CharacteristicNullStringUf8("98bd0b1c-0b0e-421a-84e5-ddbf75dc6de4")
-    contour_name_4 = CharacteristicNullStringUf8("98bd0b1d-0b0e-421a-84e5-ddbf75dc6de4")
-    contour_name_5 = CharacteristicNullStringUf8("98bd0b1e-0b0e-421a-84e5-ddbf75dc6de4")
+    contour_receive = CharacteristicBytes(
+        "98bd0b11-0b0e-421a-84e5-ddbf75dc6de4", variant="1"
+    )
+    contour_transmit = CharacteristicBytes(
+        "98bd0b12-0b0e-421a-84e5-ddbf75dc6de4", variant="1"
+    )
+    contour_info = CharacteristicBytes(
+        "98bd0b13-0b0e-421a-84e5-ddbf75dc6de4", variant="1"
+    )
+    contour_name_1 = CharacteristicNullStringUf8(
+        "98bd0b1a-0b0e-421a-84e5-ddbf75dc6de4", variant="1"
+    )
+    contour_name_2 = CharacteristicNullStringUf8(
+        "98bd0b1b-0b0e-421a-84e5-ddbf75dc6de4", variant="1"
+    )
+    contour_name_3 = CharacteristicNullStringUf8(
+        "98bd0b1c-0b0e-421a-84e5-ddbf75dc6de4", variant="1"
+    )
+    contour_name_4 = CharacteristicNullStringUf8(
+        "98bd0b1d-0b0e-421a-84e5-ddbf75dc6de4", variant="1"
+    )
+    contour_name_5 = CharacteristicNullStringUf8(
+        "98bd0b1e-0b0e-421a-84e5-ddbf75dc6de4", variant="1"
+    )
 
 
 class AquaContourSchedule(Service):
     uuid = "98bd0c10-0b0e-421a-84e5-ddbf75dc6de4"
     products = {ProductType.AQUA_CONTOURS}
+    variant = "1"
 
     schedule_1 = CharacteristicBytes("98bd0c11-0b0e-421a-84e5-ddbf75dc6de4")
     schedule_2 = CharacteristicBytes("98bd0c12-0b0e-421a-84e5-ddbf75dc6de4")
@@ -210,11 +228,19 @@ class Pump(Service):
 
 class Spray(Service):
     uuid = "98bd0110-0b0e-421a-84e5-ddbf75dc6de4"
-    distance = CharacteristicInt("98bd0111-0b0e-421a-84e5-ddbf75dc6de4")
-    sector = CharacteristicInt("98bd0112-0b0e-421a-84e5-ddbf75dc6de4")
-    current_distance = CharacteristicInt("98bd0113-0b0e-421a-84e5-ddbf75dc6de4")
-    current_sector = CharacteristicInt("98bd0114-0b0e-421a-84e5-ddbf75dc6de4")
-    watering_mode_error = CharacteristicInt("98bd0115-0b0e-421a-84e5-ddbf75dc6de4")
+    variant = "1"
+
+    distance = CharacteristicInt("98bd0111-0b0e-421a-84e5-ddbf75dc6de4", variant="1")
+    sector = CharacteristicInt("98bd0112-0b0e-421a-84e5-ddbf75dc6de4", variant="1")
+    current_distance = CharacteristicInt(
+        "98bd0113-0b0e-421a-84e5-ddbf75dc6de4", variant="1"
+    )
+    current_sector = CharacteristicInt(
+        "98bd0114-0b0e-421a-84e5-ddbf75dc6de4", variant="1"
+    )
+    watering_mode_error = CharacteristicInt(
+        "98bd0115-0b0e-421a-84e5-ddbf75dc6de4", variant="1"
+    )
 
 
 class EventHistory(Service):
@@ -225,6 +251,7 @@ class EventHistory(Service):
 
 class AquaContour(Service):
     uuid = "98bd0a10-0b0e-421a-84e5-ddbf75dc6de4"
+
     unix_timestamp = CharacteristicTime("98bd0a11-0b0e-421a-84e5-ddbf75dc6de4")
     custom_device_name = CharacteristicNullStringUf8(
         "98bd0a12-0b0e-421a-84e5-ddbf75dc6de4"

--- a/gardena_bluetooth/const.py
+++ b/gardena_bluetooth/const.py
@@ -212,8 +212,8 @@ class Pump(Service):
     flow_rate = CharacteristicUInt16("98bd0103-0b0e-421a-84e5-ddbf75dc6de4")
     ptu_mode = CharacteristicInt("98bd0104-0b0e-421a-84e5-ddbf75dc6de4")
     leakage_detection = CharacteristicBool("98bd0105-0b0e-421a-84e5-ddbf75dc6de4")
-    min_preassure = CharacteristicInt("98bd0106-0b0e-421a-84e5-ddbf75dc6de4")
-    max_preassure = CharacteristicInt("98bd0107-0b0e-421a-84e5-ddbf75dc6de4")
+    min_preassure = CharacteristicUInt16("98bd0106-0b0e-421a-84e5-ddbf75dc6de4")
+    max_preassure = CharacteristicUInt16("98bd0107-0b0e-421a-84e5-ddbf75dc6de4")
     child_lock = CharacteristicBool("98bd0108-0b0e-421a-84e5-ddbf75dc6de4")
     filter_reminder = CharacteristicInt("98bd0109-0b0e-421a-84e5-ddbf75dc6de4")
     direct_start = CharacteristicBool("98bd010a-0b0e-421a-84e5-ddbf75dc6de4")
@@ -230,12 +230,12 @@ class Spray(Service):
     uuid = "98bd0110-0b0e-421a-84e5-ddbf75dc6de4"
     variant = "1"
 
-    distance = CharacteristicInt("98bd0111-0b0e-421a-84e5-ddbf75dc6de4", variant="1")
-    sector = CharacteristicInt("98bd0112-0b0e-421a-84e5-ddbf75dc6de4", variant="1")
-    current_distance = CharacteristicInt(
+    distance = CharacteristicUInt16("98bd0111-0b0e-421a-84e5-ddbf75dc6de4", variant="1")
+    sector = CharacteristicUInt16("98bd0112-0b0e-421a-84e5-ddbf75dc6de4", variant="1")
+    current_distance = CharacteristicUInt16(
         "98bd0113-0b0e-421a-84e5-ddbf75dc6de4", variant="1"
     )
-    current_sector = CharacteristicInt(
+    current_sector = CharacteristicUInt16(
         "98bd0114-0b0e-421a-84e5-ddbf75dc6de4", variant="1"
     )
     watering_mode_error = CharacteristicInt(
@@ -265,7 +265,7 @@ class FlowStatistics(Service):
     overall = CharacteristicLong("98bd0e16-0b0e-421a-84e5-ddbf75dc6de4")
     resettable = CharacteristicLong("98bd0e17-0b0e-421a-84e5-ddbf75dc6de4")
     last_reset = CharacteristicTime("98bd0e18-0b0e-421a-84e5-ddbf75dc6de4")
-    current = CharacteristicInt("98bd0e19-0b0e-421a-84e5-ddbf75dc6de4")
+    current = CharacteristicUInt16("98bd0e19-0b0e-421a-84e5-ddbf75dc6de4")
 
 
 class AquaContourPosition(Service):

--- a/gardena_bluetooth/parse.py
+++ b/gardena_bluetooth/parse.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from enum import IntEnum, Enum, auto
 from typing import ClassVar, Generic, Self, TypeVar
@@ -52,13 +52,20 @@ CharacteristicType = TypeVar("CharacteristicType")
 @dataclass
 class Characteristic(Generic[CharacteristicType]):
     uuid: str
+    variant: str | None = None
     name: str = ""
     registry: ClassVar[dict[str, list[Self]]] = {}
+    unique_id: str = field(init=False)
 
     def __set_name__(self, _, name: str):
         self.name = pretty_name(name)
 
     def __post_init__(self):
+        if self.variant is not None:
+            unique_id = self.uuid + ":" + self.variant
+        else:
+            unique_id = self.uuid
+        object.__setattr__(self, "unique_id", unique_id)
         self.registry.setdefault(self.uuid, []).append(self)
 
     @classmethod
@@ -209,7 +216,9 @@ class CharacteristicTimeArray(Characteristic[list[datetime]]):
 
 
 class Service:
+    unique_id: ClassVar[str]
     uuid: ClassVar[str]
+    variant: ClassVar[str | None] = None
     products: ClassVar[set[ProductType]] = set(ProductType)
     registry: ClassVar[dict[str, list[Self]]] = {}
     characteristics: ClassVar[dict[str, Characteristic]] = {}
@@ -236,6 +245,10 @@ class Service:
         super().__init_subclass__(**kwargs)
         if ABC in cls.__bases__:
             return
+        if cls.variant is not None:
+            cls.unique_id = cls.uuid + ":" + cls.variant
+        else:
+            cls.unique_id = cls.uuid
         cls.registry.setdefault(cls.uuid, []).append(cls)
 
         cls.characteristics = {}

--- a/gardena_bluetooth/parse.py
+++ b/gardena_bluetooth/parse.py
@@ -1,3 +1,4 @@
+from abc import ABC
 from dataclasses import dataclass
 from datetime import datetime
 from enum import IntEnum, Enum, auto
@@ -170,6 +171,22 @@ class CharacteristicLongArray(Characteristic[list[int]]):
 
 
 @dataclass
+class CharacteristicWeekday(Characteristic[list[bool]]):
+    @classmethod
+    def decode(cls, data: bytes) -> list[bool]:
+        value = int.from_bytes(data, "little", signed=False)
+        return [(value >> i) & 1 != 0 for i in range(7)]
+
+    @classmethod
+    def encode(cls, value: list[bool]) -> bytes:
+        int_value = 0
+        for i, day in enumerate(value):
+            if day:
+                int_value |= 1 << i
+        return int_value.to_bytes(1, "little", signed=False)
+
+
+@dataclass
 class CharacteristicTime(Characteristic[datetime]):
     @classmethod
     def decode(cls, data: bytes) -> datetime:
@@ -207,6 +224,8 @@ class Service:
 
     def __init_subclass__(cls, /, **kwargs):
         super().__init_subclass__(**kwargs)
+        if ABC in cls.__bases__:
+            return
         cls.registry.setdefault(cls.uuid, []).append(cls)
 
         cls.characteristics = {}

--- a/gardena_bluetooth/parse.py
+++ b/gardena_bluetooth/parse.py
@@ -10,6 +10,7 @@ def pretty_name(name: str):
 
 
 class ProductType(Enum):
+    UNKNOWN = auto()
     MOWER = auto()
     WATER_COMPUTER = auto()
     VALVE = auto()
@@ -30,7 +31,7 @@ class ProductType(Enum):
                 return ProductType.VALVE
             if data.model == 16:
                 return ProductType.AQUA_CONTOURS
-            return None
+            return ProductType.UNKNOWN
 
         if data.group == 17:
             if data.model == 1:
@@ -39,9 +40,9 @@ class ProductType(Enum):
                 return ProductType.PRESSURE_TANKS
             if data.model == 3:
                 return ProductType.AUTOMATS
-            return None
+            return ProductType.UNKNOWN
 
-        return None
+        return ProductType.UNKNOWN
 
 
 CharacteristicType = TypeVar("CharacteristicType")
@@ -192,8 +193,17 @@ class CharacteristicTimeArray(Characteristic[list[datetime]]):
 
 class Service:
     uuid: ClassVar[str]
+    products: ClassVar[set[ProductType]] = set(ProductType)
     registry: ClassVar[dict[str, list[Self]]] = {}
     characteristics: ClassVar[dict[str, Characteristic]] = {}
+
+    @classmethod
+    def find_service(cls, uuid: str, product_type: ProductType) -> Self | None:
+        services = cls.registry.get(uuid, [])
+        for service in services:
+            if product_type in service.products:
+                return service
+        return None
 
     def __init_subclass__(cls, /, **kwargs):
         super().__init_subclass__(**kwargs)

--- a/gardena_bluetooth/parse.py
+++ b/gardena_bluetooth/parse.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from datetime import datetime
 from enum import IntEnum, Enum, auto
-from typing import ClassVar, Generic, TypeVar
+from typing import ClassVar, Generic, Self, TypeVar
 
 
 def pretty_name(name: str):
@@ -51,13 +51,13 @@ CharacteristicType = TypeVar("CharacteristicType")
 class Characteristic(Generic[CharacteristicType]):
     uuid: str
     name: str = ""
-    registry: ClassVar[dict[str, "Characteristic"]] = {}
+    registry: ClassVar[dict[str, list[Self]]] = {}
 
     def __set_name__(self, _, name: str):
         self.name = pretty_name(name)
 
     def __post_init__(self):
-        self.registry[self.uuid] = self
+        self.registry.setdefault(self.uuid, []).append(self)
 
     @classmethod
     def decode(cls, data: bytes) -> CharacteristicType:
@@ -192,17 +192,17 @@ class CharacteristicTimeArray(Characteristic[list[datetime]]):
 
 class Service:
     uuid: ClassVar[str]
-    registry: ClassVar[dict[str, "Service"]] = {}
+    registry: ClassVar[dict[str, list[Self]]] = {}
+    characteristics: ClassVar[dict[str, Characteristic]] = {}
 
     def __init_subclass__(cls, /, **kwargs):
         super().__init_subclass__(**kwargs)
-        cls.registry[cls.uuid] = cls
+        cls.registry.setdefault(cls.uuid, []).append(cls)
 
-    @classmethod
-    def characteristics(cls):
+        cls.characteristics = {}
         for value in vars(cls).values():
             if isinstance(value, Characteristic):
-                yield value
+                cls.characteristics[value.uuid] = value
 
 
 class EnumOrInt(IntEnum):

--- a/gardena_bluetooth/parse.py
+++ b/gardena_bluetooth/parse.py
@@ -222,6 +222,16 @@ class Service:
                 return service
         return None
 
+    @classmethod
+    def services_for_product_type(cls, product_type: ProductType) -> list[Self]:
+        """Get all services for a product type."""
+        return [
+            service
+            for services in Service.registry.values()
+            for service in services
+            if product_type in service.products
+        ]
+
     def __init_subclass__(cls, /, **kwargs):
         super().__init_subclass__(**kwargs)
         if ABC in cls.__bases__:

--- a/gardena_bluetooth/parse.py
+++ b/gardena_bluetooth/parse.py
@@ -233,11 +233,11 @@ class ProductGroup(EnumOrInt):
 @dataclass
 class ManufacturerData:
     company: ClassVar[int] = 0x0426
-    pairable: bool | None
-    serial: int | None
-    group: int | ProductGroup | None
-    model: int | None
-    variant: int | None
+    pairable: bool | None = None
+    serial: int | None = None
+    group: int | ProductGroup | None = None
+    model: int | None = None
+    variant: int | None = None
 
     @staticmethod
     def decode_dict(data: bytes):
@@ -252,14 +252,22 @@ class ManufacturerData:
 
     @staticmethod
     def decode(data: bytes):
+        res = ManufacturerData()
+        res.update(data)
+        return res
+
+    def update(self, data: bytes):
         value = ManufacturerData.decode_dict(data)
         info = dict(enumerate(value.get(6, b"")))
-        serial = value.get(4)
-        pairable = value.get(5)
-        return ManufacturerData(
-            pairable=bool.from_bytes(pairable, "little") if pairable else None,
-            serial=int.from_bytes(serial, "little") if serial else None,
-            group=ProductGroup.enum_or_int(info.get(0)),
-            model=info.get(1),
-            variant=info.get(2),
-        )
+
+        if (data := info.get(0)) is not None:
+            self.group = ProductGroup.enum_or_int(data)
+        if (data := info.get(1)) is not None:
+            self.model = data
+        if (data := info.get(2)) is not None:
+            self.variant = data
+
+        if (data := value.get(4)) is not None:
+            self.serial = int.from_bytes(data, "little")
+        if (data := value.get(5)) is not None:
+            self.pairable = bool.from_bytes(data, "little")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gardena-bluetooth"
-version = "1.6.0"
+version = "2.0.0"
 description = ""
 readme = "README.rst"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "gardena-bluetooth"
 version = "1.6.0"
 description = ""
 readme = "README.rst"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 authors = [
     {name = "Joakim Plate", email = "elupus@ecce.se"},
 ]

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -6,6 +6,7 @@ from gardena_bluetooth.const import (
     Schedule_4,
     Schedule_5,
 )
+from gardena_bluetooth.parse import Service, Characteristic
 import pytest
 
 
@@ -27,3 +28,14 @@ def test_schedule(schedule: type[Schedule], base: str):
     assert schedule.valve_link.uuid == f"98bd0c{base}4-0b0e-421a-84e5-ddbf75dc6de4"
     assert schedule.active.uuid == f"98bd0c{base}5-0b0e-421a-84e5-ddbf75dc6de4"
     assert schedule.sensor_link.uuid == f"98bd0c{base}6-0b0e-421a-84e5-ddbf75dc6de4"
+
+
+def test_id_uniqueness():
+    """Ensure our id's are globally unique for services and characteristics."""
+    ids: dict[str, Service | Characteristic] = {}
+    for services in Service.registry.values():
+        for service in services:
+            assert ids.setdefault(service.unique_id, service) is service
+
+            for char in service.characteristics.values():
+                assert ids.setdefault(char.unique_id, char) is char

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -1,0 +1,29 @@
+from gardena_bluetooth.const import (
+    Schedule_1,
+    Schedule,
+    Schedule_2,
+    Schedule_3,
+    Schedule_4,
+    Schedule_5,
+)
+import pytest
+
+
+@pytest.mark.parametrize(
+    "schedule,base",
+    [
+        (Schedule_1, "1"),
+        (Schedule_2, "2"),
+        (Schedule_3, "3"),
+        (Schedule_4, "4"),
+        (Schedule_5, "5"),
+    ],
+)
+def test_schedule(schedule: type[Schedule], base: str):
+    assert schedule.uuid == f"98bd0c{base}0-0b0e-421a-84e5-ddbf75dc6de4"
+    assert schedule.start_time.uuid == f"98bd0c{base}1-0b0e-421a-84e5-ddbf75dc6de4"
+    assert schedule.duration.uuid == f"98bd0c{base}2-0b0e-421a-84e5-ddbf75dc6de4"
+    assert schedule.weekdays.uuid == f"98bd0c{base}3-0b0e-421a-84e5-ddbf75dc6de4"
+    assert schedule.valve_link.uuid == f"98bd0c{base}4-0b0e-421a-84e5-ddbf75dc6de4"
+    assert schedule.active.uuid == f"98bd0c{base}5-0b0e-421a-84e5-ddbf75dc6de4"
+    assert schedule.sensor_link.uuid == f"98bd0c{base}6-0b0e-421a-84e5-ddbf75dc6de4"

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -26,7 +26,7 @@ def test_manufacturer_data():
         pairable=True, serial=0x04030201, group=32, model=0, variant=1
     )
 
-    assert ProductType.from_manufacturer_data(data) is None
+    assert ProductType.from_manufacturer_data(data) is ProductType.UNKNOWN
 
     raw = (
         b"\x05\x04\x14\x18\x00\x00\x02\x05\x01\x04\x06\x11\x02\x02"

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -40,14 +40,19 @@ def test_manufacturer_data():
     assert ProductType.from_manufacturer_data(data) is ProductType.PRESSURE_TANKS
 
 
-def test_parse_manufacturer_data_aquaprecise():
-    # For some reason the device seem to send different manufacture data
-    # while app is connection, this data is from same device in different
-    # states. Could be bootloader state maybe?
+def test_parse_manufacturer_data_segmented():
+    """Test segmented manufacturer data."""
 
     data = ManufacturerData()
     raw = bytes.fromhex("0205000406121001")
     data.update(raw)
+
+    assert data == ManufacturerData(
+        pairable=False,
+        group=ProductGroup.WATER_CONTROL,
+        model=16,
+        variant=1,
+    )
 
     raw = bytes.fromhex("0504f162c103")
     data.update(raw)

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -40,6 +40,29 @@ def test_manufacturer_data():
     assert ProductType.from_manufacturer_data(data) is ProductType.PRESSURE_TANKS
 
 
+def test_parse_manufacturer_data_aquaprecise():
+    # For some reason the device seem to send different manufacture data
+    # while app is connection, this data is from same device in different
+    # states. Could be bootloader state maybe?
+
+    raw = bytes.fromhex("0205000406121001")
+    data = ManufacturerData.decode(raw)
+    assert data == ManufacturerData(
+        pairable=False,
+        serial=None,
+        group=ProductGroup.WATER_CONTROL,
+        model=16,
+        variant=1,
+    )
+    assert ProductType.from_manufacturer_data(data) is ProductType.AQUA_CONTOURS
+
+    raw = bytes.fromhex("0504f162c103")
+    data = ManufacturerData.decode(raw)
+    assert data == ManufacturerData(
+        pairable=None, serial=63005425, group=None, model=None, variant=None
+    )
+
+
 def test_string_firmware_invalid():
     raw = b"abc\xe4"
     data = CharacteristicString.decode(raw)

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -45,22 +45,21 @@ def test_parse_manufacturer_data_aquaprecise():
     # while app is connection, this data is from same device in different
     # states. Could be bootloader state maybe?
 
+    data = ManufacturerData()
     raw = bytes.fromhex("0205000406121001")
-    data = ManufacturerData.decode(raw)
+    data.update(raw)
+
+    raw = bytes.fromhex("0504f162c103")
+    data.update(raw)
+
     assert data == ManufacturerData(
         pairable=False,
-        serial=None,
+        serial=63005425,
         group=ProductGroup.WATER_CONTROL,
         model=16,
         variant=1,
     )
     assert ProductType.from_manufacturer_data(data) is ProductType.AQUA_CONTOURS
-
-    raw = bytes.fromhex("0504f162c103")
-    data = ManufacturerData.decode(raw)
-    assert data == ManufacturerData(
-        pairable=None, serial=63005425, group=None, model=None, variant=None
-    )
 
 
 def test_string_firmware_invalid():

--- a/uv.lock
+++ b/uv.lock
@@ -1,10 +1,6 @@
 version = 1
 revision = 3
-requires-python = ">=3.10"
-resolution-markers = [
-    "python_full_version >= '3.11'",
-    "python_full_version < '3.11'",
-]
+requires-python = ">=3.11"
 
 [[package]]
 name = "aiooui"
@@ -12,56 +8,19 @@ version = "0.1.9"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/14/b7/ad0f86010bbabc4e556e98dd2921a923677188223cc524432695966f14fa/aiooui-0.1.9.tar.gz", hash = "sha256:e8c8bc59ab352419e0747628b4cce7c4e04d492574c1971e223401126389c5d8", size = 369276, upload-time = "2025-01-19T00:12:44.853Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/32/2a084b27ac45efd62213a29fb93b40a95089760c896c2e36d2f8444e3c1a/aiooui-0.1.9-cp310-cp310-manylinux_2_31_x86_64.whl", hash = "sha256:64d904b43f14dd1d8d9fcf1684d9e2f558bc5e0bd68dc10023c93355c9027907", size = 367352, upload-time = "2025-01-19T00:12:39.761Z" },
     { url = "https://files.pythonhosted.org/packages/7c/fa/b1310457adbea7adb84d2c144159f3b41341c40c80df3c10ce6b266874b3/aiooui-0.1.9-py3-none-any.whl", hash = "sha256:737a5e62d8726540218c2b70e5f966d9912121e4644f3d490daf8f3c18b182e5", size = 367404, upload-time = "2025-01-19T00:12:42.57Z" },
-]
-
-[[package]]
-name = "async-timeout"
-version = "5.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a5/ae/136395dfbfe00dfc94da3f3e136d0b13f394cba8f4841120e34226265780/async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3", size = 9274, upload-time = "2024-11-06T16:41:39.6Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fe/ba/e2081de779ca30d473f21f5b30e0e737c438205440784c7dfc81efc2b029/async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c", size = 6233, upload-time = "2024-11-06T16:41:37.9Z" },
-]
-
-[[package]]
-name = "asyncclick"
-version = "8.3.0.3"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.11'",
-]
-dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/29/3c/b266df0e8f3af371692d429eee4901d9392a14c864fa658d1cc7a5145881/asyncclick-8.3.0.3.tar.gz", hash = "sha256:2325fa89c13fab81430d4aca8bac17cb191c1b10a7aa7c13a7eea51cab5812c5", size = 288749, upload-time = "2025-10-03T09:03:23.586Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d3/d6/91ba5184580c7d1bb7448749afb0bb515ed5003c81b2cea3eb375362372e/asyncclick-8.3.0.3-py3-none-any.whl", hash = "sha256:a6fca7ed992459d8a807b5409d21aed6245d0342973dc3089a3f60560ea97c95", size = 109718, upload-time = "2025-10-03T09:03:21.854Z" },
 ]
 
 [[package]]
 name = "asyncclick"
 version = "8.3.0.7"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.11'",
-]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f9/ca/25e426d16bd0e91c1c9259112cecd17b2c2c239bdd8e5dba430f3bd5e3ef/asyncclick-8.3.0.7.tar.gz", hash = "sha256:8a80d8ac613098ee6a9a8f0248f60c66c273e22402cf3f115ed7f071acfc71d3", size = 277634, upload-time = "2025-10-11T08:35:44.841Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/01/d9/782ffcb4c97b889bc12d8276637d2739b99520390ee8fec77c07416c5d12/asyncclick-8.3.0.7-py3-none-any.whl", hash = "sha256:7607046de39a3f315867cad818849f973e29d350c10d92f251db3ff7600c6c7d", size = 109925, upload-time = "2025-10-11T08:35:43.378Z" },
-]
-
-[[package]]
-name = "backports-asyncio-runner"
-version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
 ]
 
 [[package]]
@@ -75,16 +34,9 @@ dependencies = [
     { name = "pathspec" },
     { name = "platformdirs" },
     { name = "pytokens" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/13/88/560b11e521c522440af991d46848a2bde64b5f7202ec14e1f46f9509d328/black-26.1.0.tar.gz", hash = "sha256:d294ac3340eef9c9eb5d29288e96dc719ff269a88e27b396340459dd85da4c58", size = 658785, upload-time = "2026-01-18T04:50:11.993Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/1b/523329e713f965ad0ea2b7a047eeb003007792a0353622ac7a8cb2ee6fef/black-26.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ca699710dece84e3ebf6e92ee15f5b8f72870ef984bf944a57a777a48357c168", size = 1849661, upload-time = "2026-01-18T04:59:12.425Z" },
-    { url = "https://files.pythonhosted.org/packages/14/82/94c0640f7285fa71c2f32879f23e609dd2aa39ba2641f395487f24a578e7/black-26.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5e8e75dabb6eb83d064b0db46392b25cabb6e784ea624219736e8985a6b3675d", size = 1689065, upload-time = "2026-01-18T04:59:13.993Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/78/474373cbd798f9291ed8f7107056e343fd39fef42de4a51c7fd0d360840c/black-26.1.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eb07665d9a907a1a645ee41a0df8a25ffac8ad9c26cdb557b7b88eeeeec934e0", size = 1751502, upload-time = "2026-01-18T04:59:15.971Z" },
-    { url = "https://files.pythonhosted.org/packages/29/89/59d0e350123f97bc32c27c4d79563432d7f3530dca2bff64d855c178af8b/black-26.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:7ed300200918147c963c87700ccf9966dceaefbbb7277450a8d646fc5646bf24", size = 1400102, upload-time = "2026-01-18T04:59:17.8Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/bc/5d866c7ae1c9d67d308f83af5462ca7046760158bbf142502bad8f22b3a1/black-26.1.0-cp310-cp310-win_arm64.whl", hash = "sha256:c5b7713daea9bf943f79f8c3b46f361cc5229e0e604dcef6a8bb6d1c37d9df89", size = 1207038, upload-time = "2026-01-18T04:59:19.543Z" },
     { url = "https://files.pythonhosted.org/packages/30/83/f05f22ff13756e1a8ce7891db517dbc06200796a16326258268f4658a745/black-26.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3cee1487a9e4c640dc7467aaa543d6c0097c391dc8ac74eb313f2fbf9d7a7cb5", size = 1831956, upload-time = "2026-01-18T04:59:21.38Z" },
     { url = "https://files.pythonhosted.org/packages/7d/f2/b2c570550e39bedc157715e43927360312d6dd677eed2cc149a802577491/black-26.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d62d14ca31c92adf561ebb2e5f2741bf8dea28aef6deb400d49cca011d186c68", size = 1672499, upload-time = "2026-01-18T04:59:23.257Z" },
     { url = "https://files.pythonhosted.org/packages/7a/d7/990d6a94dc9e169f61374b1c3d4f4dd3037e93c2cc12b6f3b12bc663aa7b/black-26.1.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fb1dafbbaa3b1ee8b4550a84425aac8874e5f390200f5502cf3aee4a2acb2f14", size = 1735431, upload-time = "2026-01-18T04:59:24.729Z" },
@@ -113,7 +65,6 @@ name = "bleak"
 version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "async-timeout", marker = "python_full_version < '3.11'" },
     { name = "dbus-fast", marker = "sys_platform == 'linux'" },
     { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
     { name = "pyobjc-framework-corebluetooth", marker = "sys_platform == 'darwin'" },
@@ -139,7 +90,6 @@ name = "bleak-retry-connector"
 version = "4.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "async-timeout", marker = "python_full_version < '3.11'" },
     { name = "bleak" },
     { name = "bluetooth-adapters", marker = "sys_platform == 'linux'" },
     { name = "dbus-fast", marker = "sys_platform == 'linux'" },
@@ -155,7 +105,6 @@ version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiooui" },
-    { name = "async-timeout", marker = "python_full_version < '3.11'" },
     { name = "bleak" },
     { name = "dbus-fast", marker = "sys_platform == 'linux'" },
     { name = "uart-devices" },
@@ -193,10 +142,6 @@ version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3d/f7/36515d10e85ab6d6193edbabbcae974c25d6fbabb8ead84cfd2b4ee8eaf6/dbus_fast-4.0.0.tar.gz", hash = "sha256:e1d3ee49a4a81524d7caaa2d5a31fc71075a1c977b661df958cee24bef86b8fe", size = 75082, upload-time = "2026-02-01T20:56:27.85Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/f3/55d3bb231ca5c6c7eaee736d0df47fad1da87d79c3192277072e7edcf239/dbus_fast-4.0.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a29ad81e59b328c840c9020daa855971d8f345d2c2472e9d5b200b3c82fc734", size = 832489, upload-time = "2026-02-01T21:05:00.327Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/37/f02d0a7ffa513e007d8b2ef159aaef42396172424cab9c1233183ea16795/dbus_fast-4.0.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e3d62b7a0e392a80f61227c6f314e969dd5bec36e693723728908f8e8a172885", size = 875549, upload-time = "2026-02-01T21:05:01.74Z" },
-    { url = "https://files.pythonhosted.org/packages/14/31/c418db2977cd17df67813fa6423ca1558e95697a45ebd3817f24db3bbf97/dbus_fast-4.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:35bbeb692e60ff2a0eb3f97dc4b048e92fc7ddc8468ed7bd173bc5513d4690cc", size = 837531, upload-time = "2026-02-01T21:05:03.105Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/95/eb8e8045de0b8c97336f2c6fef86582260c6c11d10ffd4ba20b19f2f0f67/dbus_fast-4.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:dfa3cb3137c727ea50d89e9e4e4ce5042e28baf36fcc8b1e3c84dff50eee70aa", size = 881970, upload-time = "2026-02-01T21:05:04.637Z" },
     { url = "https://files.pythonhosted.org/packages/a6/43/c46a4aaeb4bdc4ce7e20c3204eb7f455aa9ddf065c9cbe5fdd8c03a72752/dbus_fast-4.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:512f25a0705903047e9b55d2bc3724f06dcbfb77e0b13f10a7eb835679d3705c", size = 829838, upload-time = "2026-02-01T21:05:07.337Z" },
     { url = "https://files.pythonhosted.org/packages/5a/47/8ba9bf4027cc29c1eeb1e90828f151df6691012a67a0c3dabf4955e68f83/dbus_fast-4.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:28209c72c36f8e2bb2152c02598d353e9442d53d751efbf49870bc37ac3afcad", size = 875354, upload-time = "2026-02-01T21:05:09.516Z" },
     { url = "https://files.pythonhosted.org/packages/7e/fd/b7fbb9546d575dc73b7540a908a38ccba46239d8d838d3c41454e6a56a70/dbus_fast-4.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:618931126219f23285b33b5825dc40cfb166c8e6554f800f7c53dfb5f368289b", size = 835403, upload-time = "2026-02-01T21:05:11.176Z" },
@@ -221,20 +166,8 @@ wheels = [
 ]
 
 [[package]]
-name = "exceptiongroup"
-version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
-]
-
-[[package]]
 name = "gardena-bluetooth"
-version = "1.6.0"
+version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "bleak" },
@@ -244,12 +177,10 @@ dependencies = [
 
 [package.optional-dependencies]
 cli = [
-    { name = "asyncclick", version = "8.3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "asyncclick", version = "8.3.0.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "asyncclick" },
 ]
 test = [
-    { name = "asyncclick", version = "8.3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "asyncclick", version = "8.3.0.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "asyncclick" },
     { name = "black" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
@@ -337,7 +268,6 @@ version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b8/b6/d5612eb40be4fd5ef88c259339e6313f46ba67577a95d86c3470b951fce0/pyobjc_core-12.1.tar.gz", hash = "sha256:2bb3903f5387f72422145e1466b3ac3f7f0ef2e9960afa9bcd8961c5cbf8bd21", size = 1000532, upload-time = "2025-11-14T10:08:28.292Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/63/bf/3dbb1783388da54e650f8a6b88bde03c101d9ba93dfe8ab1b1873f1cd999/pyobjc_core-12.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:93418e79c1655f66b4352168f8c85c942707cb1d3ea13a1da3e6f6a143bacda7", size = 676748, upload-time = "2025-11-14T09:30:50.023Z" },
     { url = "https://files.pythonhosted.org/packages/95/df/d2b290708e9da86d6e7a9a2a2022b91915cf2e712a5a82e306cb6ee99792/pyobjc_core-12.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c918ebca280925e7fcb14c5c43ce12dcb9574a33cccb889be7c8c17f3bcce8b6", size = 671263, upload-time = "2025-11-14T09:31:35.231Z" },
     { url = "https://files.pythonhosted.org/packages/64/5a/6b15e499de73050f4a2c88fff664ae154307d25dc04da8fb38998a428358/pyobjc_core-12.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:818bcc6723561f207e5b5453efe9703f34bc8781d11ce9b8be286bb415eb4962", size = 678335, upload-time = "2025-11-14T09:32:20.107Z" },
     { url = "https://files.pythonhosted.org/packages/f4/d2/29e5e536adc07bc3d33dd09f3f7cf844bf7b4981820dc2a91dd810f3c782/pyobjc_core-12.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:01c0cf500596f03e21c23aef9b5f326b9fb1f8f118cf0d8b66749b6cf4cbb37a", size = 677370, upload-time = "2025-11-14T09:33:05.273Z" },
@@ -355,7 +285,6 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/02/a3/16ca9a15e77c061a9250afbae2eae26f2e1579eb8ca9462ae2d2c71e1169/pyobjc_framework_cocoa-12.1.tar.gz", hash = "sha256:5556c87db95711b985d5efdaaf01c917ddd41d148b1e52a0c66b1a2e2c5c1640", size = 2772191, upload-time = "2025-11-14T10:13:02.069Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b2/aa/2b2d7ec3ac4b112a605e9bd5c5e5e4fd31d60a8a4b610ab19cc4838aa92a/pyobjc_framework_cocoa-12.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:9b880d3bdcd102809d704b6d8e14e31611443aa892d9f60e8491e457182fdd48", size = 383825, upload-time = "2025-11-14T09:40:28.354Z" },
     { url = "https://files.pythonhosted.org/packages/3f/07/5760735c0fffc65107e648eaf7e0991f46da442ac4493501be5380e6d9d4/pyobjc_framework_cocoa-12.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:f52228bcf38da64b77328787967d464e28b981492b33a7675585141e1b0a01e6", size = 383812, upload-time = "2025-11-14T09:40:53.169Z" },
     { url = "https://files.pythonhosted.org/packages/95/bf/ee4f27ec3920d5c6fc63c63e797c5b2cc4e20fe439217085d01ea5b63856/pyobjc_framework_cocoa-12.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:547c182837214b7ec4796dac5aee3aa25abc665757b75d7f44f83c994bcb0858", size = 384590, upload-time = "2025-11-14T09:41:17.336Z" },
     { url = "https://files.pythonhosted.org/packages/ad/31/0c2e734165abb46215797bd830c4bdcb780b699854b15f2b6240515edcc6/pyobjc_framework_cocoa-12.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:5a3dcd491cacc2f5a197142b3c556d8aafa3963011110102a093349017705118", size = 384689, upload-time = "2025-11-14T09:41:41.478Z" },
@@ -374,7 +303,6 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4b/25/d21d6cb3fd249c2c2aa96ee54279f40876a0c93e7161b3304bf21cbd0bfe/pyobjc_framework_corebluetooth-12.1.tar.gz", hash = "sha256:8060c1466d90bbb9100741a1091bb79975d9ba43911c9841599879fc45c2bbe0", size = 33157, upload-time = "2025-11-14T10:13:28.064Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/1b/06914f4eb1bd8ce598fdd210e1a7411556286910fc8d8919ab7dbaebe629/pyobjc_framework_corebluetooth-12.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:937849f4d40a33afbcc56cbe90c8d1fbf30fb27a962575b9fb7e8e2c61d3c551", size = 13187, upload-time = "2025-11-14T09:44:04.098Z" },
     { url = "https://files.pythonhosted.org/packages/57/7a/26ae106beb97e9c4745065edb3ce3c2bdd91d81f5b52b8224f82ce9d5fb9/pyobjc_framework_corebluetooth-12.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:37e6456c8a076bd5a2bdd781d0324edd5e7397ef9ac9234a97433b522efb13cf", size = 13189, upload-time = "2025-11-14T09:44:06.229Z" },
     { url = "https://files.pythonhosted.org/packages/2a/56/01fef62a479cdd6ff9ee40b6e062a205408ff386ce5ba56d7e14a71fcf73/pyobjc_framework_corebluetooth-12.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fe72c9732ee6c5c793b9543f08c1f5bdd98cd95dfc9d96efd5708ec9d6eeb213", size = 13209, upload-time = "2025-11-14T09:44:08.203Z" },
     { url = "https://files.pythonhosted.org/packages/e0/6c/831139ebf6a811aed36abfdfad846bc380dcdf4e6fb751a310ce719ddcfd/pyobjc_framework_corebluetooth-12.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:5a894f695e6c672f0260327103a31ad8b98f8d4fb9516a0383db79a82a7e58dc", size = 13229, upload-time = "2025-11-14T09:44:10.463Z" },
@@ -393,7 +321,6 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/26/e8/75b6b9b3c88b37723c237e5a7600384ea2d84874548671139db02e76652b/pyobjc_framework_libdispatch-12.1.tar.gz", hash = "sha256:4035535b4fae1b5e976f3e0e38b6e3442ffea1b8aa178d0ca89faa9b8ecdea41", size = 38277, upload-time = "2025-11-14T10:16:46.235Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/76/9936d97586dbae4d7d10f3958d899ee7a763930af69b5ad03d4516178c7c/pyobjc_framework_libdispatch-12.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:50a81a29506f0e35b4dc313f97a9d469f7b668dae3ba597bb67bbab94de446bd", size = 20471, upload-time = "2025-11-14T09:52:53.134Z" },
     { url = "https://files.pythonhosted.org/packages/1f/75/c4aeab6ce7268373d4ceabbc5c406c4bbf557038649784384910932985f8/pyobjc_framework_libdispatch-12.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:954cc2d817b71383bd267cc5cd27d83536c5f879539122353ca59f1c945ac706", size = 20463, upload-time = "2025-11-14T09:52:55.703Z" },
     { url = "https://files.pythonhosted.org/packages/83/6f/96e15c7b2f7b51fc53252216cd0bed0c3541bc0f0aeb32756fefd31bed7d/pyobjc_framework_libdispatch-12.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0e9570d7a9a3136f54b0b834683bf3f206acd5df0e421c30f8fd4f8b9b556789", size = 15650, upload-time = "2025-11-14T09:52:59.284Z" },
     { url = "https://files.pythonhosted.org/packages/38/3a/d85a74606c89b6b293782adfb18711026ff79159db20fc543740f2ac0bc7/pyobjc_framework_libdispatch-12.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:58ffce5e6bcd7456b4311009480b195b9f22107b7682fb0835d4908af5a68ad0", size = 15668, upload-time = "2025-11-14T09:53:01.354Z" },
@@ -408,12 +335,10 @@ version = "9.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
     { name = "pygments" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
@@ -425,7 +350,6 @@ name = "pytest-asyncio"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
     { name = "pytest" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
@@ -440,11 +364,6 @@ version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b6/34/b4e015b99031667a7b960f888889c5bd34ef585c85e1cb56a594b92836ac/pytokens-0.4.1.tar.gz", hash = "sha256:292052fe80923aae2260c073f822ceba21f3872ced9a68bb7953b348e561179a", size = 23015, upload-time = "2026-01-30T01:03:45.924Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/24/f206113e05cb8ef51b3850e7ef88f20da6f4bf932190ceb48bd3da103e10/pytokens-0.4.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2a44ed93ea23415c54f3face3b65ef2b844d96aeb3455b8a69b3df6beab6acc5", size = 161522, upload-time = "2026-01-30T01:02:50.393Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/e9/06a6bf1b90c2ed81a9c7d2544232fe5d2891d1cd480e8a1809ca354a8eb2/pytokens-0.4.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:add8bf86b71a5d9fb5b89f023a80b791e04fba57960aa790cc6125f7f1d39dfe", size = 246945, upload-time = "2026-01-30T01:02:52.399Z" },
-    { url = "https://files.pythonhosted.org/packages/69/66/f6fb1007a4c3d8b682d5d65b7c1fb33257587a5f782647091e3408abe0b8/pytokens-0.4.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:670d286910b531c7b7e3c0b453fd8156f250adb140146d234a82219459b9640c", size = 259525, upload-time = "2026-01-30T01:02:53.737Z" },
-    { url = "https://files.pythonhosted.org/packages/04/92/086f89b4d622a18418bac74ab5db7f68cf0c21cf7cc92de6c7b919d76c88/pytokens-0.4.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:4e691d7f5186bd2842c14813f79f8884bb03f5995f0575272009982c5ac6c0f7", size = 262693, upload-time = "2026-01-30T01:02:54.871Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/7b/8b31c347cf94a3f900bdde750b2e9131575a61fdb620d3d3c75832262137/pytokens-0.4.1-cp310-cp310-win_amd64.whl", hash = "sha256:27b83ad28825978742beef057bfe406ad6ed524b2d28c252c5de7b4a6dd48fa2", size = 103567, upload-time = "2026-01-30T01:02:56.414Z" },
     { url = "https://files.pythonhosted.org/packages/3d/92/790ebe03f07b57e53b10884c329b9a1a308648fc083a6d4a39a10a28c8fc/pytokens-0.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d70e77c55ae8380c91c0c18dea05951482e263982911fc7410b1ffd1dadd3440", size = 160864, upload-time = "2026-01-30T01:02:57.882Z" },
     { url = "https://files.pythonhosted.org/packages/13/25/a4f555281d975bfdd1eba731450e2fe3a95870274da73fb12c40aeae7625/pytokens-0.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a58d057208cb9075c144950d789511220b07636dd2e4708d5645d24de666bdc", size = 248565, upload-time = "2026-01-30T01:02:59.912Z" },
     { url = "https://files.pythonhosted.org/packages/17/50/bc0394b4ad5b1601be22fa43652173d47e4c9efbf0044c62e9a59b747c56/pytokens-0.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b49750419d300e2b5a3813cf229d4e5a4c728dae470bcc89867a9ad6f25a722d", size = 260824, upload-time = "2026-01-30T01:03:01.471Z" },
@@ -496,60 +415,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f6/58/ac864a75067dcbd3b95be5ab4eb2b601d7fbc3d3d736a27e391a4f92a5c1/ruff-0.15.1-py3-none-win32.whl", hash = "sha256:660975d9cb49b5d5278b12b03bb9951d554543a90b74ed5d366b20e2c57c2098", size = 10462555, upload-time = "2026-02-12T23:09:29.899Z" },
     { url = "https://files.pythonhosted.org/packages/e0/5e/d4ccc8a27ecdb78116feac4935dfc39d1304536f4296168f91ed3ec00cd2/ruff-0.15.1-py3-none-win_amd64.whl", hash = "sha256:c820fef9dd5d4172a6570e5721704a96c6679b80cf7be41659ed439653f62336", size = 11599956, upload-time = "2026-02-12T23:09:01.157Z" },
     { url = "https://files.pythonhosted.org/packages/2a/07/5bda6a85b220c64c65686bc85bd0bbb23b29c62b3a9f9433fa55f17cda93/ruff-0.15.1-py3-none-win_arm64.whl", hash = "sha256:5ff7d5f0f88567850f45081fac8f4ec212be8d0b963e385c3f7d0d2eb4899416", size = 10874604, upload-time = "2026-02-12T23:09:05.515Z" },
-]
-
-[[package]]
-name = "tomli"
-version = "2.4.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/30/31573e9457673ab10aa432461bee537ce6cef177667deca369efb79df071/tomli-2.4.0.tar.gz", hash = "sha256:aa89c3f6c277dd275d8e243ad24f3b5e701491a860d5121f2cdd399fbb31fc9c", size = 17477, upload-time = "2026-01-11T11:22:38.165Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3c/d9/3dc2289e1f3b32eb19b9785b6a006b28ee99acb37d1d47f78d4c10e28bf8/tomli-2.4.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b5ef256a3fd497d4973c11bf142e9ed78b150d36f5773f1ca6088c230ffc5867", size = 153663, upload-time = "2026-01-11T11:21:45.27Z" },
-    { url = "https://files.pythonhosted.org/packages/51/32/ef9f6845e6b9ca392cd3f64f9ec185cc6f09f0a2df3db08cbe8809d1d435/tomli-2.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5572e41282d5268eb09a697c89a7bee84fae66511f87533a6f88bd2f7b652da9", size = 148469, upload-time = "2026-01-11T11:21:46.873Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/c2/506e44cce89a8b1b1e047d64bd495c22c9f71f21e05f380f1a950dd9c217/tomli-2.4.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:551e321c6ba03b55676970b47cb1b73f14a0a4dce6a3e1a9458fd6d921d72e95", size = 236039, upload-time = "2026-01-11T11:21:48.503Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/40/e1b65986dbc861b7e986e8ec394598187fa8aee85b1650b01dd925ca0be8/tomli-2.4.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e3f639a7a8f10069d0e15408c0b96a2a828cfdec6fca05296ebcdcc28ca7c76", size = 243007, upload-time = "2026-01-11T11:21:49.456Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/6f/6e39ce66b58a5b7ae572a0f4352ff40c71e8573633deda43f6a379d56b3e/tomli-2.4.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1b168f2731796b045128c45982d3a4874057626da0e2ef1fdd722848b741361d", size = 240875, upload-time = "2026-01-11T11:21:50.755Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/ad/cb089cb190487caa80204d503c7fd0f4d443f90b95cf4ef5cf5aa0f439b0/tomli-2.4.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:133e93646ec4300d651839d382d63edff11d8978be23da4cc106f5a18b7d0576", size = 246271, upload-time = "2026-01-11T11:21:51.81Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/63/69125220e47fd7a3a27fd0de0c6398c89432fec41bc739823bcc66506af6/tomli-2.4.0-cp311-cp311-win32.whl", hash = "sha256:b6c78bdf37764092d369722d9946cb65b8767bfa4110f902a1b2542d8d173c8a", size = 96770, upload-time = "2026-01-11T11:21:52.647Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/0d/a22bb6c83f83386b0008425a6cd1fa1c14b5f3dd4bad05e98cf3dbbf4a64/tomli-2.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:d3d1654e11d724760cdb37a3d7691f0be9db5fbdaef59c9f532aabf87006dbaa", size = 107626, upload-time = "2026-01-11T11:21:53.459Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/6d/77be674a3485e75cacbf2ddba2b146911477bd887dda9d8c9dfb2f15e871/tomli-2.4.0-cp311-cp311-win_arm64.whl", hash = "sha256:cae9c19ed12d4e8f3ebf46d1a75090e4c0dc16271c5bce1c833ac168f08fb614", size = 94842, upload-time = "2026-01-11T11:21:54.831Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/43/7389a1869f2f26dba52404e1ef13b4784b6b37dac93bac53457e3ff24ca3/tomli-2.4.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:920b1de295e72887bafa3ad9f7a792f811847d57ea6b1215154030cf131f16b1", size = 154894, upload-time = "2026-01-11T11:21:56.07Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/05/2f9bf110b5294132b2edf13fe6ca6ae456204f3d749f623307cbb7a946f2/tomli-2.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7d6d9a4aee98fac3eab4952ad1d73aee87359452d1c086b5ceb43ed02ddb16b8", size = 149053, upload-time = "2026-01-11T11:21:57.467Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/41/1eda3ca1abc6f6154a8db4d714a4d35c4ad90adc0bcf700657291593fbf3/tomli-2.4.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:36b9d05b51e65b254ea6c2585b59d2c4cb91c8a3d91d0ed0f17591a29aaea54a", size = 243481, upload-time = "2026-01-11T11:21:58.661Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/6d/02ff5ab6c8868b41e7d4b987ce2b5f6a51d3335a70aa144edd999e055a01/tomli-2.4.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1c8a885b370751837c029ef9bc014f27d80840e48bac415f3412e6593bbc18c1", size = 251720, upload-time = "2026-01-11T11:22:00.178Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/57/0405c59a909c45d5b6f146107c6d997825aa87568b042042f7a9c0afed34/tomli-2.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8768715ffc41f0008abe25d808c20c3d990f42b6e2e58305d5da280ae7d1fa3b", size = 247014, upload-time = "2026-01-11T11:22:01.238Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/0e/2e37568edd944b4165735687cbaf2fe3648129e440c26d02223672ee0630/tomli-2.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7b438885858efd5be02a9a133caf5812b8776ee0c969fea02c45e8e3f296ba51", size = 251820, upload-time = "2026-01-11T11:22:02.727Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/1c/ee3b707fdac82aeeb92d1a113f803cf6d0f37bdca0849cb489553e1f417a/tomli-2.4.0-cp312-cp312-win32.whl", hash = "sha256:0408e3de5ec77cc7f81960c362543cbbd91ef883e3138e81b729fc3eea5b9729", size = 97712, upload-time = "2026-01-11T11:22:03.777Z" },
-    { url = "https://files.pythonhosted.org/packages/69/13/c07a9177d0b3bab7913299b9278845fc6eaaca14a02667c6be0b0a2270c8/tomli-2.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:685306e2cc7da35be4ee914fd34ab801a6acacb061b6a7abca922aaf9ad368da", size = 108296, upload-time = "2026-01-11T11:22:04.86Z" },
-    { url = "https://files.pythonhosted.org/packages/18/27/e267a60bbeeee343bcc279bb9e8fbed0cbe224bc7b2a3dc2975f22809a09/tomli-2.4.0-cp312-cp312-win_arm64.whl", hash = "sha256:5aa48d7c2356055feef06a43611fc401a07337d5b006be13a30f6c58f869e3c3", size = 94553, upload-time = "2026-01-11T11:22:05.854Z" },
-    { url = "https://files.pythonhosted.org/packages/34/91/7f65f9809f2936e1f4ce6268ae1903074563603b2a2bd969ebbda802744f/tomli-2.4.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:84d081fbc252d1b6a982e1870660e7330fb8f90f676f6e78b052ad4e64714bf0", size = 154915, upload-time = "2026-01-11T11:22:06.703Z" },
-    { url = "https://files.pythonhosted.org/packages/20/aa/64dd73a5a849c2e8f216b755599c511badde80e91e9bc2271baa7b2cdbb1/tomli-2.4.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:9a08144fa4cba33db5255f9b74f0b89888622109bd2776148f2597447f92a94e", size = 149038, upload-time = "2026-01-11T11:22:07.56Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/8a/6d38870bd3d52c8d1505ce054469a73f73a0fe62c0eaf5dddf61447e32fa/tomli-2.4.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c73add4bb52a206fd0c0723432db123c0c75c280cbd67174dd9d2db228ebb1b4", size = 242245, upload-time = "2026-01-11T11:22:08.344Z" },
-    { url = "https://files.pythonhosted.org/packages/59/bb/8002fadefb64ab2669e5b977df3f5e444febea60e717e755b38bb7c41029/tomli-2.4.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fb2945cbe303b1419e2706e711b7113da57b7db31ee378d08712d678a34e51e", size = 250335, upload-time = "2026-01-11T11:22:09.951Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/3d/4cdb6f791682b2ea916af2de96121b3cb1284d7c203d97d92d6003e91c8d/tomli-2.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bbb1b10aa643d973366dc2cb1ad94f99c1726a02343d43cbc011edbfac579e7c", size = 245962, upload-time = "2026-01-11T11:22:11.27Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/4a/5f25789f9a460bd858ba9756ff52d0830d825b458e13f754952dd15fb7bb/tomli-2.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4cbcb367d44a1f0c2be408758b43e1ffb5308abe0ea222897d6bfc8e8281ef2f", size = 250396, upload-time = "2026-01-11T11:22:12.325Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/2f/b73a36fea58dfa08e8b3a268750e6853a6aac2a349241a905ebd86f3047a/tomli-2.4.0-cp313-cp313-win32.whl", hash = "sha256:7d49c66a7d5e56ac959cb6fc583aff0651094ec071ba9ad43df785abc2320d86", size = 97530, upload-time = "2026-01-11T11:22:13.865Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/af/ca18c134b5d75de7e8dc551c5234eaba2e8e951f6b30139599b53de9c187/tomli-2.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:3cf226acb51d8f1c394c1b310e0e0e61fecdd7adcb78d01e294ac297dd2e7f87", size = 108227, upload-time = "2026-01-11T11:22:15.224Z" },
-    { url = "https://files.pythonhosted.org/packages/22/c3/b386b832f209fee8073c8138ec50f27b4460db2fdae9ffe022df89a57f9b/tomli-2.4.0-cp313-cp313-win_arm64.whl", hash = "sha256:d20b797a5c1ad80c516e41bc1fb0443ddb5006e9aaa7bda2d71978346aeb9132", size = 94748, upload-time = "2026-01-11T11:22:16.009Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/c4/84047a97eb1004418bc10bdbcfebda209fca6338002eba2dc27cc6d13563/tomli-2.4.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:26ab906a1eb794cd4e103691daa23d95c6919cc2fa9160000ac02370cc9dd3f6", size = 154725, upload-time = "2026-01-11T11:22:17.269Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/5d/d39038e646060b9d76274078cddf146ced86dc2b9e8bbf737ad5983609a0/tomli-2.4.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:20cedb4ee43278bc4f2fee6cb50daec836959aadaf948db5172e776dd3d993fc", size = 148901, upload-time = "2026-01-11T11:22:18.287Z" },
-    { url = "https://files.pythonhosted.org/packages/73/e5/383be1724cb30f4ce44983d249645684a48c435e1cd4f8b5cded8a816d3c/tomli-2.4.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:39b0b5d1b6dd03684b3fb276407ebed7090bbec989fa55838c98560c01113b66", size = 243375, upload-time = "2026-01-11T11:22:19.154Z" },
-    { url = "https://files.pythonhosted.org/packages/31/f0/bea80c17971c8d16d3cc109dc3585b0f2ce1036b5f4a8a183789023574f2/tomli-2.4.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a26d7ff68dfdb9f87a016ecfd1e1c2bacbe3108f4e0f8bcd2228ef9a766c787d", size = 250639, upload-time = "2026-01-11T11:22:20.168Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/8f/2853c36abbb7608e3f945d8a74e32ed3a74ee3a1f468f1ffc7d1cb3abba6/tomli-2.4.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:20ffd184fb1df76a66e34bd1b36b4a4641bd2b82954befa32fe8163e79f1a702", size = 246897, upload-time = "2026-01-11T11:22:21.544Z" },
-    { url = "https://files.pythonhosted.org/packages/49/f0/6c05e3196ed5337b9fe7ea003e95fd3819a840b7a0f2bf5a408ef1dad8ed/tomli-2.4.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:75c2f8bbddf170e8effc98f5e9084a8751f8174ea6ccf4fca5398436e0320bc8", size = 254697, upload-time = "2026-01-11T11:22:23.058Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/f5/2922ef29c9f2951883525def7429967fc4d8208494e5ab524234f06b688b/tomli-2.4.0-cp314-cp314-win32.whl", hash = "sha256:31d556d079d72db7c584c0627ff3a24c5d3fb4f730221d3444f3efb1b2514776", size = 98567, upload-time = "2026-01-11T11:22:24.033Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/31/22b52e2e06dd2a5fdbc3ee73226d763b184ff21fc24e20316a44ccc4d96b/tomli-2.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:43e685b9b2341681907759cf3a04e14d7104b3580f808cfde1dfdb60ada85475", size = 108556, upload-time = "2026-01-11T11:22:25.378Z" },
-    { url = "https://files.pythonhosted.org/packages/48/3d/5058dff3255a3d01b705413f64f4306a141a8fd7a251e5a495e3f192a998/tomli-2.4.0-cp314-cp314-win_arm64.whl", hash = "sha256:3d895d56bd3f82ddd6faaff993c275efc2ff38e52322ea264122d72729dca2b2", size = 96014, upload-time = "2026-01-11T11:22:26.138Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/4e/75dab8586e268424202d3a1997ef6014919c941b50642a1682df43204c22/tomli-2.4.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:5b5807f3999fb66776dbce568cc9a828544244a8eb84b84b9bafc080c99597b9", size = 163339, upload-time = "2026-01-11T11:22:27.143Z" },
-    { url = "https://files.pythonhosted.org/packages/06/e3/b904d9ab1016829a776d97f163f183a48be6a4deb87304d1e0116a349519/tomli-2.4.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c084ad935abe686bd9c898e62a02a19abfc9760b5a79bc29644463eaf2840cb0", size = 159490, upload-time = "2026-01-11T11:22:28.399Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/5a/fc3622c8b1ad823e8ea98a35e3c632ee316d48f66f80f9708ceb4f2a0322/tomli-2.4.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0f2e3955efea4d1cfbcb87bc321e00dc08d2bcb737fd1d5e398af111d86db5df", size = 269398, upload-time = "2026-01-11T11:22:29.345Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/33/62bd6152c8bdd4c305ad9faca48f51d3acb2df1f8791b1477d46ff86e7f8/tomli-2.4.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0e0fe8a0b8312acf3a88077a0802565cb09ee34107813bba1c7cd591fa6cfc8d", size = 276515, upload-time = "2026-01-11T11:22:30.327Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/ff/ae53619499f5235ee4211e62a8d7982ba9e439a0fb4f2f351a93d67c1dd2/tomli-2.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:413540dce94673591859c4c6f794dfeaa845e98bf35d72ed59636f869ef9f86f", size = 273806, upload-time = "2026-01-11T11:22:32.56Z" },
-    { url = "https://files.pythonhosted.org/packages/47/71/cbca7787fa68d4d0a9f7072821980b39fbb1b6faeb5f5cf02f4a5559fa28/tomli-2.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0dc56fef0e2c1c470aeac5b6ca8cc7b640bb93e92d9803ddaf9ea03e198f5b0b", size = 281340, upload-time = "2026-01-11T11:22:33.505Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/00/d595c120963ad42474cf6ee7771ad0d0e8a49d0f01e29576ee9195d9ecdf/tomli-2.4.0-cp314-cp314t-win32.whl", hash = "sha256:d878f2a6707cc9d53a1be1414bbb419e629c3d6e67f69230217bb663e76b5087", size = 108106, upload-time = "2026-01-11T11:22:34.451Z" },
-    { url = "https://files.pythonhosted.org/packages/de/69/9aa0c6a505c2f80e519b43764f8b4ba93b5a0bbd2d9a9de6e2b24271b9a5/tomli-2.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2add28aacc7425117ff6364fe9e06a183bb0251b03f986df0e78e974047571fd", size = 120504, upload-time = "2026-01-11T11:22:35.764Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/9f/f1668c281c58cfae01482f7114a4b88d345e4c140386241a1a24dcc9e7bc/tomli-2.4.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2b1e3b80e1d5e52e40e9b924ec43d81570f0e7d09d11081b797bc4692765a3d4", size = 99561, upload-time = "2026-01-11T11:22:36.624Z" },
-    { url = "https://files.pythonhosted.org/packages/23/d1/136eb2cb77520a31e1f64cbae9d33ec6df0d78bdf4160398e86eec8a8754/tomli-2.4.0-py3-none-any.whl", hash = "sha256:1f776e7d669ebceb01dee46484485f43a4048746235e683bcdffacdf1fb4785a", size = 14477, upload-time = "2026-01-11T11:22:37.446Z" },
 ]
 
 [[package]]
@@ -609,9 +474,6 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/16/dd/acdd527c1d890c8f852cc2af644aa6c160974e66631289420aa871b05e65/winrt_runtime-3.2.1.tar.gz", hash = "sha256:c8dca19e12b234ae6c3dadf1a4d0761b51e708457492c13beb666556958801ea", size = 21721, upload-time = "2025-06-06T14:40:27.593Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/65/28/26d86ca6d2f155f31ca61e069312034a8922a5a89f5d0fc68abb7c04aad1/winrt_runtime-3.2.1-cp310-cp310-win32.whl", hash = "sha256:25a2d1e2b45423742319f7e10fa8ca2e7063f01284b6e85e99d805c4b50bbfb3", size = 210993, upload-time = "2025-06-06T06:44:01.184Z" },
-    { url = "https://files.pythonhosted.org/packages/46/a4/f096687e0d1877d206bc5d1f5f07ff90e00b0772d69d4559ab2b6b37090b/winrt_runtime-3.2.1-cp310-cp310-win_amd64.whl", hash = "sha256:dc81d5fb736bf1ddecf743928622253dce4d0aac9a57faad776d7a3834e13257", size = 242210, upload-time = "2025-06-06T06:44:02.366Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/81/46927ce4d79fc8f40f193f35204bce79eff7c496d888825a7a74d8560b6e/winrt_runtime-3.2.1-cp310-cp310-win_arm64.whl", hash = "sha256:363f584b1e9fcb601e3e178636d8877e6f0537ac3c96ce4a96f06066f8ff0eae", size = 415833, upload-time = "2025-06-06T06:44:03.379Z" },
     { url = "https://files.pythonhosted.org/packages/90/8d/d7ae0e07cd85c7768de76e8578261854f2af72bd3a8a527bb675e8ae0eda/winrt_runtime-3.2.1-cp311-cp311-win32.whl", hash = "sha256:9e9b64f1ba631cc4b9fe60b8ff16fef3f32c7ce2fcc84735a63129ff8b15c022", size = 210798, upload-time = "2025-06-06T06:44:04.775Z" },
     { url = "https://files.pythonhosted.org/packages/ac/66/d05f6e6c0517654734e7f87fa1f0fbc965add9f27cc36b524d96331ab3d8/winrt_runtime-3.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:c0a9046ae416808420a358c51705af8ae100acd40bc578be57ddfdd51cbb0f9c", size = 242032, upload-time = "2025-06-06T06:44:06.103Z" },
     { url = "https://files.pythonhosted.org/packages/39/a5/760c8396110f6d3e4c417752da1a2bf3b89e0998329c2f10afc717ef6291/winrt_runtime-3.2.1-cp311-cp311-win_arm64.whl", hash = "sha256:e94f3cb40ea2d723c44c82c16d715c03c6b3bd977d135b49535fdd5415fd9130", size = 415659, upload-time = "2025-06-06T06:44:07.007Z" },
@@ -635,9 +497,6 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b2/a0/1c8a0c469abba7112265c6cb52f0090d08a67c103639aee71fc690e614b8/winrt_windows_devices_bluetooth-3.2.1.tar.gz", hash = "sha256:db496d2d92742006d5a052468fc355bf7bb49e795341d695c374746113d74505", size = 23732, upload-time = "2025-06-06T14:41:20.489Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/b7/822da8bc0b6a67cc0c3e460fef793f00c51a6fe59aa54f6bfe416519a9d9/winrt_windows_devices_bluetooth-3.2.1-cp310-cp310-win32.whl", hash = "sha256:49489351037094a088a08fbdf0f99c94e3299b574edb211f717c4c727770af78", size = 105569, upload-time = "2025-06-06T07:00:05.406Z" },
-    { url = "https://files.pythonhosted.org/packages/68/46/696893d3bae80751e35fb0fb8fae5e7fc94a5354dfb5e19167d415e27c66/winrt_windows_devices_bluetooth-3.2.1-cp310-cp310-win_amd64.whl", hash = "sha256:20f6a21029034c18ea6a6b6df399671813b071102a0d6d8355bb78cf4f547cdb", size = 114743, upload-time = "2025-06-06T07:00:06.408Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/6a/a36b28739b73cc2c67050da866b063af135b5f6c071997c85a27adb6815c/winrt_windows_devices_bluetooth-3.2.1-cp310-cp310-win_arm64.whl", hash = "sha256:69c523814eab795bc1bf913292309cb1025ef0a67d5fc33863a98788995e551d", size = 105021, upload-time = "2025-06-06T07:00:07.299Z" },
     { url = "https://files.pythonhosted.org/packages/3b/cf/671bf29337323cc08f9969cb32312f217d2927d29dbf2964f0dbb378cb90/winrt_windows_devices_bluetooth-3.2.1-cp311-cp311-win32.whl", hash = "sha256:f4082a00b834c1e34b961e0612f3e581356bdb38c5798bd6842f88ec02e5152b", size = 105535, upload-time = "2025-06-06T07:00:08.146Z" },
     { url = "https://files.pythonhosted.org/packages/b6/d5/5761a8b6dcc56957018970dd443059c8ee8a79de7b07f0b4d143f8e7dc15/winrt_windows_devices_bluetooth-3.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:44277a3f2cc5ac32ce9b4b2d96c5c5f601d394ac5f02cc71bcd551f738660e2d", size = 114612, upload-time = "2025-06-06T07:00:08.984Z" },
     { url = "https://files.pythonhosted.org/packages/24/0b/7819bb102286752d3572a75d03e6a8000ffe3c6cb7aee3eb136dca383fe2/winrt_windows_devices_bluetooth-3.2.1-cp311-cp311-win_arm64.whl", hash = "sha256:0803a417403a7d225316b9b0c4fe3f8446579d6a22f2f729a2c21f4befc74a80", size = 105017, upload-time = "2025-06-06T07:00:09.813Z" },
@@ -661,9 +520,6 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/06/fc/7ffe66ca4109b9e994b27c00f3d2d506e6e549e268791f755287ad9106d8/winrt_windows_devices_bluetooth_advertisement-3.2.1.tar.gz", hash = "sha256:0223852a7b7fa5c8dea3c6a93473bd783df4439b1ed938d9871f947933e574cc", size = 16906, upload-time = "2025-06-06T14:41:21.448Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/b9/c2b0d201b8b38895809591d089a5edc37e702a23f3a6bc6e542c5e7d6dbf/winrt_windows_devices_bluetooth_advertisement-3.2.1-cp310-cp310-win32.whl", hash = "sha256:a758c5f81a98cc38347fdfb024ce62720969480e8c5b98e402b89d2b09b32866", size = 89730, upload-time = "2025-06-06T07:00:18.451Z" },
-    { url = "https://files.pythonhosted.org/packages/56/f9/f086c3ac17745a71d8384e1831cab0d5a7c737e1fe5cb84d7584f6c14bbf/winrt_windows_devices_bluetooth_advertisement-3.2.1-cp310-cp310-win_amd64.whl", hash = "sha256:f982ef72e729ddd60cdb975293866e84bb838798828933012a57ee4bf12b0ea1", size = 95825, upload-time = "2025-06-06T07:00:19.385Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/b5/f7f830b2da1fb7ffcaf25ce2734db0019615111f8f39e7b4d83fea4a0bd0/winrt_windows_devices_bluetooth_advertisement-3.2.1-cp310-cp310-win_arm64.whl", hash = "sha256:e88a72e1e09c7ccc899a9e6d2ab3fc0f43b5dd4509bcc49ec4abf65b55ab015f", size = 89402, upload-time = "2025-06-06T07:00:20.178Z" },
     { url = "https://files.pythonhosted.org/packages/ad/5e/c628719e877a89f00cac7ce53f9666acbc5ed6f074130729d5d6768b63ff/winrt_windows_devices_bluetooth_advertisement-3.2.1-cp311-cp311-win32.whl", hash = "sha256:fe17c2cf63284646622e8b2742b064bf7970bbf53cfab02062136c67fa6b06c9", size = 89614, upload-time = "2025-06-06T07:00:20.952Z" },
     { url = "https://files.pythonhosted.org/packages/ac/1a/d172d6f1c2fae53535e7f23835025cf39e3002749a0304f18a38e8ed490d/winrt_windows_devices_bluetooth_advertisement-3.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:78e99dd48b4d89b71b7778c5085fdba64e754dd3ebc54fd09c200fe5222c6e09", size = 95783, upload-time = "2025-06-06T07:00:21.764Z" },
     { url = "https://files.pythonhosted.org/packages/67/c1/568dfdaea62ca3b13bb70162cb292e5cd0be5bbb98b738961ddcc2edd374/winrt_windows_devices_bluetooth_advertisement-3.2.1-cp311-cp311-win_arm64.whl", hash = "sha256:6d5d2295474deab444fc4311580c725a2ca8a814b0f3344d0779828891d75401", size = 89253, upload-time = "2025-06-06T07:00:22.603Z" },
@@ -687,9 +543,6 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/44/21/aeeddc0eccdfbd25e543360b5cc093233e2eab3cdfb53ad3cabae1b5d04d/winrt_windows_devices_bluetooth_genericattributeprofile-3.2.1.tar.gz", hash = "sha256:cdf6ddc375e9150d040aca67f5a17c41ceaf13a63f3668f96608bc1d045dde71", size = 38896, upload-time = "2025-06-06T14:41:22.687Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/66/a3/449ffc2f8e4c3cfbe7f14c1b43bcaa0475fbd2e8e8bf08465399c5ea078c/winrt_windows_devices_bluetooth_genericattributeprofile-3.2.1-cp310-cp310-win32.whl", hash = "sha256:af4914d7b30b49232092cd3b934e3ed6f5d3b1715ba47238541408ee595b7f46", size = 182059, upload-time = "2025-06-06T07:00:47.095Z" },
-    { url = "https://files.pythonhosted.org/packages/50/d9/6ea88731df569f5c1b086daf4c3496c8d43281588e3a578ea623fef6bc43/winrt_windows_devices_bluetooth_genericattributeprofile-3.2.1-cp310-cp310-win_amd64.whl", hash = "sha256:0e557dd52fc80392b8bd7c237e1153a50a164b3983838b4ac674551072efc9ed", size = 187866, upload-time = "2025-06-06T07:00:48.123Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/2c/ace56fd32ad07608462de0ac7df218e0bf810e4cc31f2c0fbd7f5f90ee93/winrt_windows_devices_bluetooth_genericattributeprofile-3.2.1-cp310-cp310-win_arm64.whl", hash = "sha256:64cff62baa6b7aadd6c206e61d149113fdcda17360feb6e9d05bc8bbda4b9fde", size = 184627, upload-time = "2025-06-06T07:00:49.087Z" },
     { url = "https://files.pythonhosted.org/packages/fa/5e/349a5d958be8c0570f0a49bbb746088bcfaa81555accb57503ba01185359/winrt_windows_devices_bluetooth_genericattributeprofile-3.2.1-cp311-cp311-win32.whl", hash = "sha256:832cf65d035a11e6dbfef4fd66abdcc46be7e911ec96e2e72e98e12d8d5b9d3c", size = 182312, upload-time = "2025-06-06T07:00:49.974Z" },
     { url = "https://files.pythonhosted.org/packages/90/db/929ab0085ec89e46bd3a58c74b451dd770c3285dfa0cbd4f4aa4730da004/winrt_windows_devices_bluetooth_genericattributeprofile-3.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:8179638a6c721b0bbf04ba251ef98d5e02d9a17f0cce377398e42c4fbb441415", size = 187768, upload-time = "2025-06-06T07:00:50.853Z" },
     { url = "https://files.pythonhosted.org/packages/a3/53/f316e2224c384178204430439f04f9b72017fe8237e341a9aebb20da8191/winrt_windows_devices_bluetooth_genericattributeprofile-3.2.1-cp311-cp311-win_arm64.whl", hash = "sha256:70b7edfca3190b89ae38bf60972b11978311b6d933d3142ae45560c955dbf5c7", size = 184189, upload-time = "2025-06-06T07:00:51.791Z" },
@@ -713,9 +566,6 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9e/dd/75835bfbd063dffa152109727dedbd80f6e92ea284855f7855d48cdf31c9/winrt_windows_devices_enumeration-3.2.1.tar.gz", hash = "sha256:df316899e39bfc0ffc1f3cb0f5ee54d04e1d167fbbcc1484d2d5121449a935cf", size = 23538, upload-time = "2025-06-06T14:41:26.787Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/61/2744d0e0b3fa7807149a1a36dd89abba901d6b24184d9fd5ef3f28467232/winrt_windows_devices_enumeration-3.2.1-cp310-cp310-win32.whl", hash = "sha256:40dac777d8f45b41449f3ff1ae70f0d457f1ede53f53962a6e2521b651533db5", size = 130040, upload-time = "2025-06-06T07:01:56.337Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/f9/881b7ee8acdf3c9fe6c79d8ccd90f9246b397fc78420d55014c4ac05b822/winrt_windows_devices_enumeration-3.2.1-cp310-cp310-win_amd64.whl", hash = "sha256:a101ec3e0ad0a0783032fdcd5dc48e7cd68ee034cbde4f903a8c7b391532c71a", size = 142463, upload-time = "2025-06-06T07:01:57.554Z" },
-    { url = "https://files.pythonhosted.org/packages/12/db/b09dffcf1158b35d81d8d57bf19ad04293870cea5afa77943c87f1110d88/winrt_windows_devices_enumeration-3.2.1-cp310-cp310-win_arm64.whl", hash = "sha256:3296a3863ac086928ff3f3dc872b2a2fb971dab728817424264f3ca547504e9e", size = 135871, upload-time = "2025-06-06T07:01:58.792Z" },
     { url = "https://files.pythonhosted.org/packages/a6/92/ca1fd311d96fce15fba25543a2ae3cb829744a8af548a11d74233d0e4f64/winrt_windows_devices_enumeration-3.2.1-cp311-cp311-win32.whl", hash = "sha256:9f29465a6c6b0456e4330d4ad09eccdd53a17e1e97695c2e57db0d4666cc0011", size = 129898, upload-time = "2025-06-06T07:01:59.687Z" },
     { url = "https://files.pythonhosted.org/packages/03/fd/5bd5da5d7997725ba3f1995c16aa1c3362937f8ff68ad4cadfd3415eebcb/winrt_windows_devices_enumeration-3.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:2a725d04b4cb43aa0e2af035f73a60d16a6c0ff165fcb6b763383e4e33a975fd", size = 142361, upload-time = "2025-06-06T07:02:00.546Z" },
     { url = "https://files.pythonhosted.org/packages/df/be/d423b63e740600e0617ddb85fba3ef99e7bbff02299fe46323bfe624a382/winrt_windows_devices_enumeration-3.2.1-cp311-cp311-win_arm64.whl", hash = "sha256:6365ef5978d4add26678827286034acf474b6b133aa4054e76567d12194e6817", size = 135808, upload-time = "2025-06-06T07:02:01.4Z" },
@@ -739,9 +589,6 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5e/02/9704ea359ad8b0d6faa1011f98fb477e8fb6eac5201f39d19e73c2407e7b/winrt_windows_devices_radios-3.2.1.tar.gz", hash = "sha256:4dc9b9d1501846049eb79428d64ec698d6476c27a357999b78a8331072e18a0b", size = 5908, upload-time = "2025-06-06T14:41:44.868Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7d/1b/0de659ed4bb80aee28753b4431011334205637a2578481a511866a11e0cf/winrt_windows_devices_radios-3.2.1-cp310-cp310-win32.whl", hash = "sha256:f97766fd551d06c102155d51b2922f96663dee045e1f8d57177def0a2149cb78", size = 38643, upload-time = "2025-06-06T07:07:56.852Z" },
-    { url = "https://files.pythonhosted.org/packages/29/fd/67c6db8a3244ecc95f85970a7b0e749cda28e26563db1274c3db36a8fbe4/winrt_windows_devices_radios-3.2.1-cp310-cp310-win_amd64.whl", hash = "sha256:104b737fa1279a3b6a88ba3c6236157afc1de03c472657c45e5176ad7a209e23", size = 40295, upload-time = "2025-06-06T07:07:57.738Z" },
-    { url = "https://files.pythonhosted.org/packages/15/6d/d145c7f90b01c24f4f9885d1f7d430ecaf2a2b42b6bc236701791b0b0a06/winrt_windows_devices_radios-3.2.1-cp310-cp310-win_arm64.whl", hash = "sha256:55b02877d2de06ca6f0f6140611a9af9d0c65710e28f1afdeaac1040433b1837", size = 37060, upload-time = "2025-06-06T07:07:58.47Z" },
     { url = "https://files.pythonhosted.org/packages/6b/a0/4a8b51da15de218cec04bcc1cd85b4b93bcfd8ebe50a5f0a7eee28836dc6/winrt_windows_devices_radios-3.2.1-cp311-cp311-win32.whl", hash = "sha256:7c02790472414b6cda00d24a8cd23bca18e4b7474ddad4f9264f4484b891807e", size = 38505, upload-time = "2025-06-06T07:07:59.204Z" },
     { url = "https://files.pythonhosted.org/packages/de/49/ba69e3180585dbc6f3336a09fef7cba4558a6a1e7d500500f62c1478418e/winrt_windows_devices_radios-3.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:f87745486d313ba1e7562ca97f25ad436ec01ad4b3b9ea349fb6b6f25cb41104", size = 40157, upload-time = "2025-06-06T07:07:59.948Z" },
     { url = "https://files.pythonhosted.org/packages/9c/92/64817f71a20ecf842da36dc3848f42614217688137a69c93fda8a6103155/winrt_windows_devices_radios-3.2.1-cp311-cp311-win_arm64.whl", hash = "sha256:6cee6f946ff3a3571850d1ca745edaee7c331d06ca321873e650779654effc4a", size = 36976, upload-time = "2025-06-06T07:08:00.719Z" },
@@ -765,9 +612,6 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0c/55/098ce7ea0679efcc1298b269c48768f010b6c68f90c588f654ec874c8a74/winrt_windows_foundation-3.2.1.tar.gz", hash = "sha256:ad2f1fcaa6c34672df45527d7c533731fdf65b67c4638c2b4aca949f6eec0656", size = 30485, upload-time = "2025-06-06T14:41:53.344Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/69/d387332c4378b41f87211b7dc40a4cfc6b7047dc227448aaa207624fc911/winrt_windows_foundation-3.2.1-cp310-cp310-win32.whl", hash = "sha256:677e98165dcbbf7a2367f905bc61090ef2c568b6e465f87cf7276df4734f3b0b", size = 111969, upload-time = "2025-06-06T07:10:55.77Z" },
-    { url = "https://files.pythonhosted.org/packages/52/71/046c1e2424627c3db66d764871186de4d26936e8a138d6bf04dc143e4606/winrt_windows_foundation-3.2.1-cp310-cp310-win_amd64.whl", hash = "sha256:a8f27b4f0fdb73ccc4a3e24bc8010a6607b2bdd722fa799eafce7daa87d19d39", size = 118695, upload-time = "2025-06-06T07:10:56.782Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/2e/2463bc4ad984836fb3ecf1abac62df67bc5cabab004cad09b828b86ed51b/winrt_windows_foundation-3.2.1-cp310-cp310-win_arm64.whl", hash = "sha256:d900c6165fab4ea589811efa2feed27b532e1b6f505f63bf63e2052b8cb6bdc4", size = 109690, upload-time = "2025-06-06T07:10:57.618Z" },
     { url = "https://files.pythonhosted.org/packages/c0/36/09b9757f7cbf269e67008ea2ad188a44f974c94c9b49ebf0b52d1a8c4069/winrt_windows_foundation-3.2.1-cp311-cp311-win32.whl", hash = "sha256:d1b5970241ccd61428f7330d099be75f4f52f25e510d82c84dbbdaadd625e437", size = 111944, upload-time = "2025-06-06T07:10:58.496Z" },
     { url = "https://files.pythonhosted.org/packages/05/a5/216d66df6bdcee58eb3877fabc1544337e23f850bf9f93838db7f5698371/winrt_windows_foundation-3.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:f3762be2f6e0f2aedf83a0742fd727290b397ffe3463d963d29211e4ebb53a7e", size = 118465, upload-time = "2025-06-06T07:10:59.678Z" },
     { url = "https://files.pythonhosted.org/packages/be/ca/48ca8b5bc5be5c7a5516c9e1d9a21861b4217e1b4ee57923aab6f13fa411/winrt_windows_foundation-3.2.1-cp311-cp311-win_arm64.whl", hash = "sha256:806c77818217b3476e6c617293b3d5b0ff8a9901549dc3417586f6799938d671", size = 109609, upload-time = "2025-06-06T07:11:00.54Z" },
@@ -791,9 +635,6 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/62/d21e3f1eeb8d47077887bbf0c3882c49277a84d8f98f7c12bda64d498a07/winrt_windows_foundation_collections-3.2.1.tar.gz", hash = "sha256:0eff1ad0d8d763ad17e9e7bbd0c26a62b27215016393c05b09b046d6503ae6d5", size = 16043, upload-time = "2025-06-06T14:41:53.983Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/35/26/ed3d35ea262999d28be957c35a32e93360eac0ef9f14e75d32cd6b5c6a37/winrt_windows_foundation_collections-3.2.1-cp310-cp310-win32.whl", hash = "sha256:46948484addfc4db981dab35688d4457533ceb54d4954922af41503fddaa8389", size = 59880, upload-time = "2025-06-06T07:11:10.177Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/39/b4a1aeba2d13c1f2ad3d851d5092b8397c05f34fb318d6a7d499f5b5720b/winrt_windows_foundation_collections-3.2.1-cp310-cp310-win_amd64.whl", hash = "sha256:899eaa3a93c35bfb1857d649e8dd60c38b978dda7cedd9725fcdbcebba156fd6", size = 70650, upload-time = "2025-06-06T07:11:11.396Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/74/f8a4a29202da24f2af2c4a8f515b0a44fe46bc4d25b3d54ea2249e980bd3/winrt_windows_foundation_collections-3.2.1-cp310-cp310-win_arm64.whl", hash = "sha256:c36eb49ad1eba1b32134df768bb47af13cabb9b59f974a3cea37843e2d80e0e6", size = 59216, upload-time = "2025-06-06T07:11:12.575Z" },
     { url = "https://files.pythonhosted.org/packages/87/b3/7e4a75c62e86bedf9458b7ec8dfed74cff3236e0b4b2288f95967d5cc4d2/winrt_windows_foundation_collections-3.2.1-cp311-cp311-win32.whl", hash = "sha256:9b272d9936e7db4840881c5dcf921eb26789ae4ef23fb6ec15e13e19a16254e7", size = 59693, upload-time = "2025-06-06T07:11:13.388Z" },
     { url = "https://files.pythonhosted.org/packages/32/58/049db1d95fdfc0c8451dc6db17442ed4e6b2aba361c425c0bb8dc8c98c4a/winrt_windows_foundation_collections-3.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:c646a5d442dd6540ade50890081ca118b41f073356e19032d0a5d7d0d38fbc89", size = 70828, upload-time = "2025-06-06T07:11:14.54Z" },
     { url = "https://files.pythonhosted.org/packages/5b/6b/a04974f5555c86452e54c19d063d9fd45f0fe9f2a6858e7fe12c639043fb/winrt_windows_foundation_collections-3.2.1-cp311-cp311-win_arm64.whl", hash = "sha256:2c4630027c93cdd518b0cf4cc726b8fbdbc3388e36d02aa1de190a0fc18ca523", size = 59051, upload-time = "2025-06-06T07:11:15.379Z" },
@@ -817,9 +658,6 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/00/50/f4488b07281566e3850fcae1021f0285c9653992f60a915e15567047db63/winrt_windows_storage_streams-3.2.1.tar.gz", hash = "sha256:476f522722751eb0b571bc7802d85a82a3cae8b1cce66061e6e758f525e7b80f", size = 34335, upload-time = "2025-06-06T14:43:23.905Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/4d/a0d806f4664b9bcf525bd31dcdf1f9520cc14f033e897dc7f7dd4ad4eb77/winrt_windows_storage_streams-3.2.1-cp310-cp310-win32.whl", hash = "sha256:89bb2d667ebed6861af36ed2710757456e12921ee56347946540320dacf6c003", size = 127791, upload-time = "2025-06-06T14:01:56.192Z" },
-    { url = "https://files.pythonhosted.org/packages/99/2c/00baa87041a3d92a3cc5230d4033e995a52740e9c08fcd9f7bde93cb979f/winrt_windows_storage_streams-3.2.1-cp310-cp310-win_amd64.whl", hash = "sha256:48a78e5dc7d3488eb77e449c278bc6d6ac28abcdda7df298462c4112d7635d00", size = 132608, upload-time = "2025-06-06T14:01:57.3Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/d0/ed03e864aa8eaaec964d5bbc95baccf738275ae6cc88600db66ecb5adaf4/winrt_windows_storage_streams-3.2.1-cp310-cp310-win_arm64.whl", hash = "sha256:da71231d4a554f9f15f1249b4990c6431176f6dfb0e3385c7caa7896f4ca24d6", size = 128495, upload-time = "2025-06-06T14:01:58.124Z" },
     { url = "https://files.pythonhosted.org/packages/19/60/a9e0dc03434aa29e6b5c83067e988cd5934adf830cd9f87cbbc06569ca32/winrt_windows_storage_streams-3.2.1-cp311-cp311-win32.whl", hash = "sha256:7dace2f9e364422255d0e2f335f741bfe7abb1f4d4f6003622b2450b87c91e69", size = 127509, upload-time = "2025-06-06T14:01:58.971Z" },
     { url = "https://files.pythonhosted.org/packages/23/98/6c9c21b5e75ff5927a130da9eaf5ab628dfa1f93b64c181f0193706cbd6c/winrt_windows_storage_streams-3.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:b02fa251a7eef6081eca1a5f64ecf349cfd1ac0ac0c5a5a30be52897d060bed5", size = 132491, upload-time = "2025-06-06T14:01:59.788Z" },
     { url = "https://files.pythonhosted.org/packages/38/ca/d0a02045d445cbf1029d65f01b487fdded5b333c0367a8bae0565b3def00/winrt_windows_storage_streams-3.2.1-cp311-cp311-win_arm64.whl", hash = "sha256:efdf250140340a75647e8e8ad002782d91308e9fdd1e19470a5b9cc969ae4780", size = 128577, upload-time = "2025-06-06T14:02:00.623Z" },


### PR DESCRIPTION
This requires supporting selecting services and characteristics based on the product type, since annoyingly they have re-used UUID's with different meaning on these devices.