### PR TITLE
feat: support Smart Water Control (G-19033/19034) over BLE

### DIFF
--- a/gardena_bluetooth/client.py
+++ b/gardena_bluetooth/client.py
@@ -3,7 +3,10 @@ import logging
 from collections.abc import Awaitable, Callable
 from contextlib import asynccontextmanager
 from datetime import datetime
-from typing import TypeVar, overload
+from typing import TYPE_CHECKING, TypeVar, overload
+
+if TYPE_CHECKING:
+    from .const import ValveX
 
 from bleak import BleakClient
 from bleak.backends.characteristic import BleakGATTCharacteristic
@@ -291,6 +294,33 @@ class Client:
             callback(value)
 
         return self.subscribe_char_raw(char.uuid, _callback)
+
+    async def start_watering(
+        self,
+        service: "type[ValveX]",
+        duration_seconds: int,
+    ) -> None:
+        """Open a Valve1/Valve2-family valve for ``duration_seconds``.
+
+        Writes the LWM2M Execute payload reverse-engineered from
+        cloudless-garden/gardena-smart-local-api:
+        ``{0: WATERING_COMMAND_SOURCE, 1: str(duration_seconds)}`` →
+        ASCII bytes ``b"0='18',1='<n>'"``. Without key 0 the device
+        silently ignores the write. ``service`` must be a ValveX
+        subclass (e.g. ``Valve1`` or ``Valve2``).
+        """
+        from .const import WATERING_COMMAND_SOURCE
+
+        await self.write_char(
+            service.start_watering,
+            {0: WATERING_COMMAND_SOURCE, 1: str(duration_seconds)},
+        )
+
+    async def stop_watering(self, service: "type[ValveX]") -> None:
+        """Close a Valve1/Valve2-family valve."""
+        from .const import WATERING_COMMAND_SOURCE
+
+        await self.write_char(service.stop_watering, {0: WATERING_COMMAND_SOURCE})
 
     async def update_timestamp(self, char: CharacteristicTime, now: datetime):
         try:

--- a/gardena_bluetooth/const.py
+++ b/gardena_bluetooth/const.py
@@ -46,6 +46,13 @@ PRODUCT_NAMES = {
 ScanService = "98bd0001-0b0e-421a-84e5-ddbf75dc6de4"
 FotaService = "0000ffc0-0000-1000-8000-00805f9b34fb"
 
+# Source marker written as key 0 to ValveX.start_watering / .stop_watering.
+# Matches COMMAND_SOURCE in cloudless-garden/gardena-smart-local-api — the
+# value the smart gateway sends as command originator. Without this key,
+# the Valve1/Valve2 family (wc_single, wc_dual, G-1903x) silently ignores
+# the write even though the GATT layer accepts it.
+WATERING_COMMAND_SOURCE = "18"
+
 
 class Scan(Service):
     uuid = "98bd0001-0b0e-421a-84e5-ddbf75dc6de4"
@@ -72,12 +79,12 @@ class Valve(Service):
 class ValveX(Service, ABC):
     available: ClassVar[CharacteristicBool]
     manual_watering_duration: ClassVar[CharacteristicLong]
-    error = ClassVar[CharacteristicInt]
+    error: ClassVar[CharacteristicInt]
     state: ClassVar[CharacteristicBool]
     remaining_time_open: ClassVar[CharacteristicLong]
     activation_reason: ClassVar[CharacteristicIntEnum]
-    start_watering = ClassVar[CharacteristicString]
-    stop_watering = ClassVar[CharacteristicString]
+    start_watering: ClassVar[CharacteristicIntKeys]
+    stop_watering: ClassVar[CharacteristicIntKeys]
 
 
 class Valve1(ValveX):

--- a/gardena_bluetooth/const.py
+++ b/gardena_bluetooth/const.py
@@ -472,8 +472,23 @@ class AquaContourPosition(Service):
 
 
 class AquaContourBattery(Service):
+    """Standard BLE Battery Service (0x180f).
+
+    Originally only resolved for ``AQUA_CONTOURS``; the newer
+    Valve1/Valve2 family (``wc_single``, ``wc_dual``, pipeline, …) also
+    exposes battery state through the same standard service rather than
+    the Gardena-proprietary ``Battery`` (98bd180f) used by legacy
+    01889-20 devices. Expanded to cover ``WATER_COMPUTER`` and ``VALVE``
+    so consumers like Home Assistant's gardena_bluetooth integration
+    surface a battery sensor for those devices.
+    """
+
     uuid = "0000180f-0000-1000-8000-00805f9b34fb"
-    products = {ProductType.AQUA_CONTOURS}
+    products = {
+        ProductType.AQUA_CONTOURS,
+        ProductType.WATER_COMPUTER,
+        ProductType.VALVE,
+    }
 
     battery_level = CharacteristicInt("00002a19-0000-1000-8000-00805f9b34fb")
     battery_level_status = CharacteristicInt("00002bed-0000-1000-8000-00805f9b34fb")

--- a/gardena_bluetooth/scan.py
+++ b/gardena_bluetooth/scan.py
@@ -41,9 +41,12 @@ async def advertisement_queue(backend: type[BaseBleakScanner] | None = None):
     def _callback(device, advertisement):
         queue.put_nowait((device, advertisement))
 
-    scanner = BleakScanner(
-        backend=backend, service_uuids=[ScanService], detection_callback=_callback
-    )
+    # NOTE: do NOT pass service_uuids=[ScanService] here. On macOS the
+    # CoreBluetooth-level filter hides devices that don't advertise the scan
+    # service UUID in their ad packet — the newer Smart Water Control
+    # G-19033-20 advertises only manufacturer data, no service UUIDs. The
+    # async iterator below filters by Gardena's manufacturer id (0x0426).
+    scanner = BleakScanner(backend=backend, detection_callback=_callback)
 
     await scanner.start()
     try:
@@ -61,7 +64,13 @@ async def async_scan_devices(
     async with advertisement_queue(backend) as queue:
         while True:
             device, advertisement = await queue.get()
-            if ScanService not in advertisement.service_uuids:
+            # Accept either the legacy scan-service-uuid advert OR the newer
+            # G-19033-20 packets that only carry manufacturer data.
+            if (
+                ScanService not in advertisement.service_uuids
+                and ManufacturerData.company
+                not in (advertisement.manufacturer_data or {})
+            ):
                 continue
 
             data = devices.get(device.address)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gardena-bluetooth"
-version = "2.8.1"
+version = "2.9.0"
 description = ""
 readme = "README.rst"
 requires-python = ">=3.12"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,10 +1,11 @@
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from bleak.backends.device import BLEDevice
 from bleak.exc import BleakError
 
 from gardena_bluetooth.client import DEFAULT_DELAY, CachedConnection, Client
+from gardena_bluetooth.const import Valve1, Valve2
 from gardena_bluetooth.exceptions import CommunicationFailure
 
 
@@ -30,3 +31,43 @@ async def test_establish_connection_failure_raises_communication_failure():
             await client.read_char_raw("00000000-0000-0000-0000-000000000000")
 
     assert cached_connection._client is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("service", "expected_uuid"),
+    [
+        (Valve1, "98bda020-0b0e-421a-84e5-ddbf75dc6de4"),
+        (Valve2, "98bda120-0b0e-421a-84e5-ddbf75dc6de4"),
+    ],
+)
+async def test_start_watering_writes_lwm2m_execute_payload(service, expected_uuid):
+    """start_watering must encode {0:'18', 1:str(duration)} on the right char."""
+    device = BLEDevice(address="AA:BB:CC:DD:EE:FF", name="Gardena", details=None)
+    client = Client(CachedConnection(DEFAULT_DELAY, lambda: device))
+    client._unique_id = {service.start_watering.unique_id}
+
+    with patch.object(client, "write_char_raw", new=AsyncMock()) as mock_write:
+        await client.start_watering(service, 30)
+
+    mock_write.assert_awaited_once_with(expected_uuid, b"0='18',1='30'", None)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("service", "expected_uuid"),
+    [
+        (Valve1, "98bda021-0b0e-421a-84e5-ddbf75dc6de4"),
+        (Valve2, "98bda121-0b0e-421a-84e5-ddbf75dc6de4"),
+    ],
+)
+async def test_stop_watering_writes_command_source_only(service, expected_uuid):
+    """stop_watering must encode {0:'18'} on the right char."""
+    device = BLEDevice(address="AA:BB:CC:DD:EE:FF", name="Gardena", details=None)
+    client = Client(CachedConnection(DEFAULT_DELAY, lambda: device))
+    client._unique_id = {service.stop_watering.unique_id}
+
+    with patch.object(client, "write_char_raw", new=AsyncMock()) as mock_write:
+        await client.stop_watering(service)
+
+    mock_write.assert_awaited_once_with(expected_uuid, b"0='18'", None)

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -2,6 +2,7 @@ import pytest
 
 from gardena_bluetooth.const import (
     WATERING_COMMAND_SOURCE,
+    AquaContourBattery,
     Schedule,
     Schedule_1,
     Schedule_2,
@@ -12,7 +13,12 @@ from gardena_bluetooth.const import (
     Valve2,
     ValveX,
 )
-from gardena_bluetooth.parse import Characteristic, CharacteristicIntKeys, Service
+from gardena_bluetooth.parse import (
+    Characteristic,
+    CharacteristicIntKeys,
+    ProductType,
+    Service,
+)
 
 
 @pytest.mark.parametrize(
@@ -73,3 +79,24 @@ def test_valvex_stop_watering_payload_format():
     """The encoded stop payload carries just key 0 = COMMAND_SOURCE."""
     raw = Valve1.stop_watering.encode({0: WATERING_COMMAND_SOURCE})
     assert raw == b"0='18'"
+
+
+@pytest.mark.parametrize(
+    "product_type",
+    [
+        ProductType.AQUA_CONTOURS,
+        ProductType.WATER_COMPUTER,
+        ProductType.VALVE,
+    ],
+)
+def test_standard_battery_service_covers_water_control_family(
+    product_type: ProductType,
+) -> None:
+    """The standard BLE Battery Service (0x180f) is exposed by the AquaContour
+    family AND the newer Valve1/Valve2 family (wc_single, wc_dual, irrigation
+    valve). Without this, HA's gardena_bluetooth integration cannot surface a
+    battery sensor for those devices because services_for_product_type filters
+    by ProductType.
+    """
+    assert product_type in AquaContourBattery.products
+    assert AquaContourBattery in Service.services_for_product_type(product_type)

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -1,14 +1,18 @@
 import pytest
 
 from gardena_bluetooth.const import (
+    WATERING_COMMAND_SOURCE,
     Schedule,
     Schedule_1,
     Schedule_2,
     Schedule_3,
     Schedule_4,
     Schedule_5,
+    Valve1,
+    Valve2,
+    ValveX,
 )
-from gardena_bluetooth.parse import Characteristic, Service
+from gardena_bluetooth.parse import Characteristic, CharacteristicIntKeys, Service
 
 
 @pytest.mark.parametrize(
@@ -40,3 +44,32 @@ def test_id_uniqueness():
 
             for char in service.characteristics.values():
                 assert ids.setdefault(char.unique_id, char) is char
+
+
+def test_watering_command_source():
+    """WATERING_COMMAND_SOURCE matches gardena-smart-local-api COMMAND_SOURCE."""
+    assert WATERING_COMMAND_SOURCE == "18"
+
+
+@pytest.mark.parametrize("service", [Valve1, Valve2])
+def test_valvex_start_stop_are_int_keys(service: type[ValveX]):
+    """start/stop_watering must be CharacteristicIntKeys (not String).
+
+    The Valve1/Valve2 family expects the LWM2M Execute serialisation
+    `0='<source>',1='<duration>'` — CharacteristicIntKeys is the codec
+    for that.
+    """
+    assert isinstance(service.start_watering, CharacteristicIntKeys)
+    assert isinstance(service.stop_watering, CharacteristicIntKeys)
+
+
+def test_valvex_start_watering_payload_format():
+    """The encoded start payload uses key 0 for COMMAND_SOURCE, key 1 for duration."""
+    raw = Valve1.start_watering.encode({0: WATERING_COMMAND_SOURCE, 1: "30"})
+    assert raw == b"0='18',1='30'"
+
+
+def test_valvex_stop_watering_payload_format():
+    """The encoded stop payload carries just key 0 = COMMAND_SOURCE."""
+    raw = Valve1.stop_watering.encode({0: WATERING_COMMAND_SOURCE})
+    assert raw == b"0='18'"


### PR DESCRIPTION
# `elupus/gardena-bluetooth` PR

**Branch:** `feat/wc-single-dual-support`
**Base:** `master`
**Title:** `feat: support Smart Water Control (G-19033/19034) over BLE`

## Summary

Adds BLE discovery + valve actuation support for the new Smart Water
Control family of devices (G-19033-20 "wc_single", G-19034-20 "wc_dual",
G-19050-20 "Pipeline Water Control", etc.). These have been sold since
2025 and are the direct successors of the now-EOL Bluetooth-only 01889-20.

Fixes the recurring "no devices found" reports against this device family
(home-assistant/core#167291, home-assistant/discussions/3056) by:

1. **Relaxing the scanner UUID filter** — the new devices don't advertise
   the legacy `ScanService` UUID, so the existing `service_uuids=[ScanService]`
   filter made them completely invisible (especially on macOS where the
   filter is enforced at the CoreBluetooth layer).

2. **Documenting the actuation protocol** — `Valve1.start_watering` is a
   `CharacteristicIntKeys` characteristic. Without the right key 0 the
   device accepts writes at the GATT layer but silently refuses to
   actuate. The required key 0 value (`"18"`) was reverse-engineered from
   cloudless-garden/gardena-smart-local-api where the smart-gateway path
   uses the same LWM2M-Execute serialisation — added as the
   `WATERING_COMMAND_SOURCE` constant.

3. **Adding `Client.start_watering` / `Client.stop_watering`** convenience
   methods so consumers don't have to know about the LWM2M serialisation.

4. **Fixing three pre-existing annotation typos** in `ValveX`
   (`=` instead of `:`, `CharacteristicString` instead of
   `CharacteristicIntKeys`).

5. **Exposing the standard BLE Battery service to the Valve1/Valve2
   family** — the `wc_single`/`wc_dual` devices report battery via the
   standard `0x180f` / `0x2a19` UUIDs that `AquaContourBattery` already
   models, but the class was gated to `products={AQUA_CONTOURS}` so
   `Service.services_for_product_type(WATER_COMPUTER)` did not include
   it and consumers (HA's battery sensor entity description) couldn't
   reach the characteristic. Expanded `products` to also cover
   `WATER_COMPUTER` and `VALVE`.

## Commits

| message |
|---------|
| fix(scan): drop ScanService UUID filter to support G-1903x devices |
| feat(const): WATERING_COMMAND_SOURCE + fix ValveX annotations |
| feat(client): start_watering / stop_watering helpers for Valve1/Valve2 |
| chore: bump version 2.8.1 → 2.9.0 |
| test: cover WATERING_COMMAND_SOURCE + Client watering helpers |
| feat(const): expose standard BLE Battery service to Valve1/2 family |

Diff is ~140 lines net (includes 8 new test cases).

## Verification

End-to-end against a G-19033-20 (firmware 1.1.1) on macOS Sequoia, host
running Python 3.12 / bleak 3.0.2:

```text
WATERING_COMMAND_SOURCE = '18'
Discovered: 8E200707-...  G-19033  RSSI=-42
  pairable=True, serial=17747, group=WATER_CONTROL,
  model=SINGLE_WATER_CONTROL, variant=0
  → ProductType.WATER_COMPUTER

>>> client.start_watering(Valve1, 30)
  t+0.5s  state=True  remaining=26s  activation_reason=18  ✓
>>> client.stop_watering(Valve1)
  t+0.5s  state=False remaining=0s   activation_reason=0   ✓
```

Without the scan-filter fix, the device was completely invisible
(`scan` ran for minutes with no hits). With the fix but without the
`WATERING_COMMAND_SOURCE` key 0, writes to `start_watering` were
accepted but never actuated the valve.

## Protocol notes (for future maintainers)

The Valve1/Valve2 services follow Gardena's LWM2M-over-BLE convention
that mirrors the smart-gateway protocol:

* `start_watering` (`98bda020` / `98bda120`) accepts a `CharacteristicIntKeys`
  payload `{0: "18", 1: "<seconds>"}` → ASCII `0='18',1='<n>'`. Equivalent
  to LWM2M `Execute /actuator/<id>/start` with args
  `[COMMAND_SOURCE="18", str(duration_seconds)]`.
* `stop_watering` (`98bda021` / `98bda121`) accepts `{0: "18"}`.
* `activation_reason` is set to the value of key 0 — so a third-party
  client gets `activation_reason=18` while the official gateway uses a
  different source code.
* The third write-only char in each Valve1 service (`98bda022`) accepts
  writes but I couldn't observe any state change for `0='18'` or
  `0='18',1='0'` payloads — likely close-all or admin command, deferred.

## Companion home-assistant/core PR

The matching HA-component update (Valve1/Valve2 entities, second BT
discovery matcher, etc.) is filed as <link to companion PR>.
