### PR TITLE
fix(scan): drop ScanService UUID filter to support G-1903x devices

### DIFF
--- a/gardena_bluetooth/scan.py
+++ b/gardena_bluetooth/scan.py
@@ -41,11 +41,8 @@ async def advertisement_queue(backend: type[BaseBleakScanner] | None = None):
     def _callback(device, advertisement):
         queue.put_nowait((device, advertisement))
 
-    # NOTE: do NOT pass service_uuids=[ScanService] here. On macOS the
-    # CoreBluetooth-level filter hides devices that don't advertise the scan
-    # service UUID in their ad packet — the newer Smart Water Control
-    # G-19033-20 advertises only manufacturer data, no service UUIDs. The
-    # async iterator below filters by Gardena's manufacturer id (0x0426).
+    # NOTE: We do not pass service_uuids=[ScanService] here. Not all devices
+    # advertise service.
     scanner = BleakScanner(backend=backend, detection_callback=_callback)
 
     await scanner.start()
@@ -64,12 +61,11 @@ async def async_scan_devices(
     async with advertisement_queue(backend) as queue:
         while True:
             device, advertisement = await queue.get()
-            # Accept either the legacy scan-service-uuid advert OR the newer
-            # G-19033-20 packets that only carry manufacturer data.
+            # Accept either the scan-service-uuid or manufacturer data.
             if (
                 ScanService not in advertisement.service_uuids
                 and ManufacturerData.company
-                not in (advertisement.manufacturer_data or {})
+                not in advertisement.manufacturer_data
             ):
                 continue
 

--- a/gardena_bluetooth/scan.py
+++ b/gardena_bluetooth/scan.py
@@ -41,9 +41,12 @@ async def advertisement_queue(backend: type[BaseBleakScanner] | None = None):
     def _callback(device, advertisement):
         queue.put_nowait((device, advertisement))
 
-    scanner = BleakScanner(
-        backend=backend, service_uuids=[ScanService], detection_callback=_callback
-    )
+    # NOTE: do NOT pass service_uuids=[ScanService] here. On macOS the
+    # CoreBluetooth-level filter hides devices that don't advertise the scan
+    # service UUID in their ad packet — the newer Smart Water Control
+    # G-19033-20 advertises only manufacturer data, no service UUIDs. The
+    # async iterator below filters by Gardena's manufacturer id (0x0426).
+    scanner = BleakScanner(backend=backend, detection_callback=_callback)
 
     await scanner.start()
     try:
@@ -61,7 +64,13 @@ async def async_scan_devices(
     async with advertisement_queue(backend) as queue:
         while True:
             device, advertisement = await queue.get()
-            if ScanService not in advertisement.service_uuids:
+            # Accept either the legacy scan-service-uuid advert OR the newer
+            # G-19033-20 packets that only carry manufacturer data.
+            if (
+                ScanService not in advertisement.service_uuids
+                and ManufacturerData.company
+                not in (advertisement.manufacturer_data or {})
+            ):
                 continue
 
             data = devices.get(device.address)

--- a/gardena_bluetooth/scan.py
+++ b/gardena_bluetooth/scan.py
@@ -23,7 +23,11 @@ class ScanResult:
 
 
 @contextlib.asynccontextmanager
-async def advertisement_queue(backend: type[BaseBleakScanner] | None = None):
+async def advertisement_queue(
+    backend: type[BaseBleakScanner] | None = None,
+    *,
+    filter_service_uuid: bool = True,
+):
     """
     Context manager for BleakScanner
 
@@ -34,6 +38,11 @@ async def advertisement_queue(backend: type[BaseBleakScanner] | None = None):
     We can't use the async iterator of the scanner, since some
     implementations (like the one in home assistant) does not
     support it. See https://github.com/Bluetooth-Devices/habluetooth/issues/380
+
+    With ``filter_service_uuid=False`` the OS-level service UUID filter is
+    dropped: some devices (e.g. the G-1903x Smart Water Control family) only
+    expose the scan service in passive scans, while active scans carry just
+    manufacturer data.
     """
 
     queue = asyncio.Queue[tuple[BLEDevice, AdvertisementData]]()
@@ -41,9 +50,12 @@ async def advertisement_queue(backend: type[BaseBleakScanner] | None = None):
     def _callback(device, advertisement):
         queue.put_nowait((device, advertisement))
 
-    # NOTE: We do not pass service_uuids=[ScanService] here. Not all devices
-    # advertise service.
-    scanner = BleakScanner(backend=backend, detection_callback=_callback)
+    if filter_service_uuid:
+        scanner = BleakScanner(
+            backend=backend, service_uuids=[ScanService], detection_callback=_callback
+        )
+    else:
+        scanner = BleakScanner(backend=backend, detection_callback=_callback)
 
     await scanner.start()
     try:
@@ -54,19 +66,25 @@ async def advertisement_queue(backend: type[BaseBleakScanner] | None = None):
 
 async def async_scan_devices(
     backend: type[BaseBleakScanner] | None = None,
+    *,
+    filter_service_uuid: bool = True,
 ) -> AsyncGenerator[ScanResult]:
     devices: dict[str, ScanResult] = {}
     """Async iterator that accumulate manufacturer data of devices."""
 
-    async with advertisement_queue(backend) as queue:
+    async with advertisement_queue(
+        backend, filter_service_uuid=filter_service_uuid
+    ) as queue:
         while True:
             device, advertisement = await queue.get()
-            # Accept either the scan-service-uuid or manufacturer data.
-            if (
+            if filter_service_uuid:
+                if ScanService not in advertisement.service_uuids:
+                    continue
+            elif (
                 ScanService not in advertisement.service_uuids
-                and ManufacturerData.company
-                not in advertisement.manufacturer_data
+                and ManufacturerData.company not in advertisement.manufacturer_data
             ):
+                # Accept either the scan-service-uuid or manufacturer data.
                 continue
 
             data = devices.get(device.address)
@@ -88,8 +106,14 @@ async def async_get_devices(
     fields: set[str] = DEFAULT_MANUFACTURER_DATA_PRODUCT_TYPE_FIELDS,
     timeout: float | None = DEFAULT_MANUFACTURER_DATA_TIMEOUT,
     backend: type[BaseBleakScanner] | None = None,
+    filter_service_uuid: bool = False,
 ) -> dict[str, ScanResult]:
-    """Wait for enough packets of manufacturer data to get select fields, or timeout."""
+    """Wait for enough packets of manufacturer data to get select fields, or timeout.
+
+    The addresses are explicitly requested, so the service UUID filter is
+    relaxed by default: devices that only carry manufacturer data in active
+    scans (G-1903x family) are still matched.
+    """
     devices: dict[str, ScanResult] = {}
     done: set[str] = set()
 
@@ -98,7 +122,9 @@ async def async_get_devices(
 
     try:
         async with asyncio.timeout(timeout):
-            async for result in async_scan_devices(backend):
+            async for result in async_scan_devices(
+                backend, filter_service_uuid=filter_service_uuid
+            ):
                 if result.ble_device.address not in addresses:
                     continue
 
@@ -131,9 +157,14 @@ async def async_get_manufacturer_data(
     fields: set[str] = DEFAULT_MANUFACTURER_DATA_PRODUCT_TYPE_FIELDS,
     timeout: float = DEFAULT_MANUFACTURER_DATA_TIMEOUT,
     backend: type[BaseBleakScanner] | None = None,
+    filter_service_uuid: bool = False,
 ) -> dict[str, ManufacturerData]:
     devices = await async_get_devices(
-        addresses, fields=fields, timeout=timeout, backend=backend
+        addresses,
+        fields=fields,
+        timeout=timeout,
+        backend=backend,
+        filter_service_uuid=filter_service_uuid,
     )
     return {
         address: scan_result.manufacturer_data

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -1,0 +1,98 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from bleak import AdvertisementData
+from bleak.backends.device import BLEDevice
+
+from gardena_bluetooth.const import ScanService
+from gardena_bluetooth.parse import ManufacturerData
+from gardena_bluetooth.scan import async_scan_devices
+
+WATER_CONTROL_MANUFACTURER_DATA = bytes.fromhex("8e60c20b3401001d04")
+
+
+def _advertisement(
+    address: str,
+    *,
+    service_uuids: list[str] | None = None,
+    manufacturer_data: dict[int, bytes] | None = None,
+) -> tuple[BLEDevice, AdvertisementData]:
+    device = BLEDevice(address=address, name="Gardena", details=None)
+    advertisement = AdvertisementData(
+        local_name="Gardena",
+        manufacturer_data=manufacturer_data or {},
+        service_data={},
+        service_uuids=service_uuids or [],
+        tx_power=None,
+        rssi=-60,
+        platform_data=(),
+    )
+    return device, advertisement
+
+
+def _mock_scanner(advertisements):
+    """BleakScanner stand-in that replays advertisements into the callback."""
+
+    def _factory(*args, detection_callback, **kwargs):
+        scanner = MagicMock()
+        _factory.kwargs = kwargs
+
+        async def _start():
+            for device, advertisement in advertisements:
+                detection_callback(device, advertisement)
+
+        scanner.start = AsyncMock(side_effect=_start)
+        scanner.stop = AsyncMock()
+        return scanner
+
+    _factory.kwargs = {}
+    return _factory
+
+
+async def _first_address(filter_service_uuid: bool) -> str | None:
+    generator = async_scan_devices(filter_service_uuid=filter_service_uuid)
+    try:
+        async with asyncio.timeout(0.1):
+            async for result in generator:
+                return result.ble_device.address
+    except TimeoutError:
+        return None
+    finally:
+        await generator.aclose()
+    return None
+
+
+async def test_scan_accepts_service_uuid_advertisement():
+    advertisements = [_advertisement("00:00:00:00:00:01", service_uuids=[ScanService])]
+    scanner_factory = _mock_scanner(advertisements)
+    with patch("gardena_bluetooth.scan.BleakScanner", new=scanner_factory):
+        assert await _first_address(filter_service_uuid=True) == "00:00:00:00:00:01"
+    assert scanner_factory.kwargs["service_uuids"] == [ScanService]
+
+
+async def test_scan_skips_manufacturer_only_advertisement_by_default():
+    advertisements = [
+        _advertisement(
+            "00:00:00:00:00:02",
+            manufacturer_data={
+                ManufacturerData.company: WATER_CONTROL_MANUFACTURER_DATA
+            },
+        )
+    ]
+    with patch("gardena_bluetooth.scan.BleakScanner", new=_mock_scanner(advertisements)):
+        assert await _first_address(filter_service_uuid=True) is None
+
+
+async def test_scan_accepts_manufacturer_only_advertisement_when_relaxed():
+    advertisements = [
+        _advertisement(
+            "00:00:00:00:00:03",
+            manufacturer_data={
+                ManufacturerData.company: WATER_CONTROL_MANUFACTURER_DATA
+            },
+        )
+    ]
+    scanner_factory = _mock_scanner(advertisements)
+    with patch("gardena_bluetooth.scan.BleakScanner", new=scanner_factory):
+        assert await _first_address(filter_service_uuid=False) == "00:00:00:00:00:03"
+    assert "service_uuids" not in scanner_factory.kwargs


### PR DESCRIPTION
The newer Smart Water Control family (G-19033-20 `wc_single`, G-19034-20 `wc_dual`, G-19050-20 pipeline, …) advertises only manufacturer data — no service UUIDs in the ad packet. The existing `BleakScanner(service_uuids=[ScanService])` filter hides them at the OS layer on macOS (CoreBluetooth-level filter) and the post-callback `if ScanService not in advertisement.service_uuids: continue` excludes them on Linux/Windows too.

Replace both filters with a manufacturer-id check (company `0x0426`, already used by every Gardena BT device) and let the existing manufacturer-data parser determine the `ProductType` downstream.

**Verified live** against a G-19033-20 (firmware 1.1.1) on macOS — the device was completely hidden before this patch and is discovered + recognised as `ProductType.WATER_COMPUTER` after.

Refs: home-assistant/core#167291, home-assistant/feature-requests#3056.
