### PR TITLE
fix(const): correct ValveX class annotations

### DIFF
--- a/gardena_bluetooth/const.py
+++ b/gardena_bluetooth/const.py
@@ -72,12 +72,12 @@ class Valve(Service):
 class ValveX(Service, ABC):
     available: ClassVar[CharacteristicBool]
     manual_watering_duration: ClassVar[CharacteristicLong]
-    error = ClassVar[CharacteristicInt]
+    error: ClassVar[CharacteristicInt]
     state: ClassVar[CharacteristicBool]
     remaining_time_open: ClassVar[CharacteristicLong]
     activation_reason: ClassVar[CharacteristicIntEnum]
-    start_watering = ClassVar[CharacteristicString]
-    stop_watering = ClassVar[CharacteristicString]
+    start_watering: ClassVar[CharacteristicIntKeys]
+    stop_watering: ClassVar[CharacteristicIntKeys]
 
 
 class Valve1(ValveX):


### PR DESCRIPTION
Three pre-existing typos in the `ValveX` abstract base:

| field | bug | fix |
|---|---|---|
| `error` | `=` instead of `:` in the annotation — creates a class attribute holding `ClassVar[CharacteristicInt]` rather than declaring the attribute type. | `:` |
| `start_watering` | same `=` typo, plus the type was `CharacteristicString` while every concrete subclass (`Valve1`, `Valve2`) declares the attribute as `CharacteristicIntKeys`. | `: ClassVar[CharacteristicIntKeys]` |
| `stop_watering` | same as `start_watering`. | `: ClassVar[CharacteristicIntKeys]` |

No behavioural change — the concrete subclasses define the right runtime types already; this only fixes the abstract-base declaration so static type checkers see `start/stop_watering` / `error` on `type[ValveX]`. Prerequisite for the type signatures used by the new `Client.start_watering` / `stop_watering` helpers in the follow-up PR.
